### PR TITLE
feat(specialists): adiciona specsfy-specialist-hermes

### DIFF
--- a/docs/user/specialists.md
+++ b/docs/user/specialists.md
@@ -39,6 +39,7 @@ skills nunca instala o catálogo inteiro automaticamente.
 | frontend | React, Astro, Next.js, TypeScript e Tailwind CSS |
 | interface | shadcn/ui, UI, UX e acessibilidade web |
 | plataforma | Docker, Docker Swarm, Ansible e engenharia de entrega |
+| agentes | Hermes Agent (autoria de skills/plugins e operação do runtime) |
 | qualidade | segurança, observabilidade e performance |
 | design técnico | arquitetura e modelagem de domínio |
 | engenharia | code review, debugging, prototipação, pesquisa e conflitos Git |

--- a/specialists/catalog.json
+++ b/specialists/catalog.json
@@ -30,6 +30,7 @@
     {"name":"specsfy-specialist-prototyping","description":"Protótipos descartáveis para reduzir incerteza técnica ou de interface.","category":"engineering","tags":["prototype","spike","experiment"],"detect":{"files":[],"dependencies":[]}},
     {"name":"specsfy-specialist-technical-research","description":"Pesquisa técnica rastreável em fontes primárias e artefatos observáveis.","category":"engineering","tags":["research","evidence","documentation"],"detect":{"files":[],"dependencies":[]}},
     {"name":"specsfy-specialist-merge-conflict-resolution","description":"Resolução de conflitos Git preservando intenção e verificando integração.","category":"engineering","tags":["git","merge","rebase"],"detect":{"files":[],"dependencies":[]}},
-    {"name":"specsfy-specialist-gitflow","description":"Gitflow: branches main/develop/feature/release/hotfix, nomes, política de merge e ciclo de release.","category":"engineering","tags":["git","gitflow","branching"],"detect":{"files":[],"dependencies":[]}}
+    {"name":"specsfy-specialist-gitflow","description":"Gitflow: branches main/develop/feature/release/hotfix, nomes, política de merge e ciclo de release.","category":"engineering","tags":["git","gitflow","branching"],"detect":{"files":[],"dependencies":[]}},
+    {"name":"specsfy-specialist-hermes","description":"Hermes Agent: autorar skills/plugins e configurar modelos, providers, gateway, cron e CLI.","category":"platform","tags":["hermes","agents","automation","skills"],"detect":{"files":[".hermes.md","HERMES.md"],"dependencies":[]}}
   ]
 }

--- a/specialists/specsfy-specialist-code-review/SKILL.md
+++ b/specialists/specsfy-specialist-code-review/SKILL.md
@@ -96,6 +96,9 @@ description: Revisar diffs, branches e PRs por contrato, correção, segurança,
 - `$specsfy-specialist-merge-conflict-resolution` quando a revisão precisar
   ser refeita após uma resolução de conflito, já que a resolução pode mudar
   o comportamento resultante.
+- `$specsfy-specialist-hermes` quando o diff for sobre autoria ou configuração
+  de skills, plugins, cron ou config do Hermes Agent — a fronteira dele é o
+  artefato do runtime, não a revisão de código em geral.
 
 Leia [references/standards.md](references/standards.md) para as lentes de
 revisão, a escala de severidade, o formato de achado e as fontes oficiais de

--- a/specialists/specsfy-specialist-hermes/SKILL.md
+++ b/specialists/specsfy-specialist-hermes/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: specsfy-specialist-hermes
+description: "Autorar skills e plugins do Hermes Agent e configurar/operar modelos, providers, gateway, cron, memória e o CLI. Use quando o projeto contém `.hermes.md`, `HERMES.md` ou diretório `.hermes/` e a tarefa toca SKILL.md, frontmatter, `references/`, `scripts/`, `config.yaml`, plugins, cron ou comandos `hermes`; não use para revisão genérica de código — combine com `specsfy-specialist-code-review` quando a tarefa for auditar a qualidade de um diff comum."
+---
+
+# Hermes Agent
+
+## Quando usar
+
+- Acionar quando o repositório tem `.hermes.md`, `HERMES.md` ou um diretório
+  `.hermes/`, e a tarefa autorar/editar SKILL.md (frontmatter, `references/`,
+  `templates/`, `scripts/`), plugins, cron jobs, ou configurar modelos,
+  providers, gateway, memória ou toolsets do Hermes Agent.
+- Acionar também para instalar/atualizar o Hermes, diagnosticar com
+  `hermes doctor`, ajustar `config.yaml` via CLI, subir o gateway ou operar
+  skills/toolsets/plugins.
+- Não acionar para revisão genérica de um diff de código comum — usar
+  `$specsfy-specialist-code-review` e trazer de volta só a parte de
+  skill/config do Hermes.
+- Combinar com `$specsfy-specialist-code-review` quando a mudança misturar
+  código de aplicação com artefatos do Hermes; cada skill audita a sua
+  fronteira sem duplicar a norma da outra.
+
+## Fluxo
+
+1. Descobrir o estado real antes de recomendar: `hermes --version`, o
+   `$HERMES_HOME` efetivo (ou `~/.hermes` quando não houver profile ativo) e os
+   arquivos já presentes (`config.yaml`, `.env`, `skills/`, `plugins/`). Nunca
+   assumir caminho, provider ou versão por memória.
+2. Confirmar o alvo da mudança — artefato de skill (SKILL.md + `references/`/
+   `templates/`/`scripts/`), plugin, cron job ou configuração (`model`,
+   `gateway`, `memory`, `approvals`, `delegation`).
+3. Aplicar a edição na camada correta: settings em `config.yaml` SEMPRE via
+   `hermes config set <seção>.<chave> <valor>`; segredos só em `.env`;
+   artefatos de skill em arquivos versionados. Nunca editar `config.yaml` à mão.
+4. Verificar a consistência antes de declarar pronto: frontmatter parseia como
+   YAML, `description` ≤ 60 caracteres com ponto final, `name`/`version`/
+   `platforms`/`metadata.hermes` presentes, e todo `related_skills` aponta para
+   uma skill existente.
+5. Validar em runtime com o comando real do ecossistema (`hermes config check`,
+   `hermes doctor`, `hermes skills check`, `hermes mcp test`, `hermes cron
+   list`, `hermes gateway status`).
+6. Registrar na spec o risco residual — por exemplo, mudança de toolset ou de
+   model que só faz efeito após `/reset` (novo sessão), preservando o prompt
+   cache.
+
+## Padrões
+
+- Settings em `config.yaml`, segredos em `.env` (ou `$HERMES_HOME/.env`) — nunca
+  colocar credencial em `config.yaml` nem setting em `.env`.
+- Configurar pelo CLI, não por edição manual: `hermes config set
+  <seção>.<chave> <valor>`; indentação errada corrompe o arquivo e quebra o
+  gateway ao vivo.
+- Resolver caminhos de profile por `$HERMES_HOME`, nunca hardcodar `~/.hermes`
+  quando houver profile ativo.
+- Manter `description` de SKILL.md com no máximo 60 caracteres, uma frase,
+  terminada em ponto, sem palavras de marketing e sem repetir o `name` — é o
+  gatilho que roda em toda sessão e o índice do sistema trunca aos 57 caracteres.
+- Referências longas fora do corpo: conteúdo extenso vai em `references/*.md`,
+  `templates/` e `scripts/`, referenciado por caminho relativo, nunca inline.
+- Autor humano primeiro no campo `author` de skills contribuídas (ex.
+  `Nome (handle), Hermes Agent`), nunca `Hermes Agent` sozinho.
+- Sem caminhos locais de máquina em artefatos versionados (skills/plugins):
+  usar caminhos relativos ao repo.
+- Não quebrar o prompt cache no meio de uma conversa: mudanças de toolsets,
+  system prompt ou contexto passado exigem `/reset` (sessão nova), não edição
+  a quente.
+- Cron jobs que devem notificar a pessoa precisam de `deliver` apontando para
+  um canal conectado ao gateway; `deliver` default/origin não entrega nada no
+  CLI.
+
+## Antipadrões
+
+- Editar `config.yaml` com `write_file`/`patch` em vez de `hermes config set` —
+  sintoma: gateway que deixa de subir após um recuo de indentação.
+- Gravar API key ou token em `config.yaml` ou em SKILL.md versionado — expõe o
+  segredo no Git e viola a separação settings/secrets.
+- `description` genérica ou com o gatilho enterrado além do caractere 57 — a
+  skill deixa de rotear e o agente nunca a carrega.
+- `related_skills` apontando para skill que não existe no repo — quebra a
+  validação e deixa referência órfã.
+- Toolset desabilitado no meio de uma tarefa para "economizar contexto" — muda
+  o system prompt e invalida o cache; a troca é por `/reset`, não a quente.
+- Chamar o especialista para revisar código comum de aplicação que não é
+  skill/plugin/config do Hermes — desperdiça a fronteira e desvia a skill de
+  code review.
+
+## Validação
+
+- `hermes doctor --fix` — dependências e config consistentes antes de declarar
+  o ambiente pronto.
+- `hermes config check` — seções ausentes de um config antigo; falha revela
+  chave esquecida após migração.
+- `hermes skills check` (ou o validador de frontmatter) — `name`, `description`
+  ≤ 60 com ponto final, `version`, `platforms` e `metadata.hermes` presentes e
+  YAML válido.
+- `hermes mcp test <nome>` — servidor MCP alcançável antes de declarar a
+  integração funcionando.
+- `hermes gateway status` e `hermes cron list` — gateway e jobs reais, não
+  supostos.
+- Não declarar uma skill "publicável" ou um gateway "operando" sem a evidência
+  acima; linguagem absoluta sem prova é proibida.
+
+## Skills relacionadas
+
+- `$specsfy-specialist-code-review` para auditar a qualidade de um diff comum;
+  a fronteira deste especialista é a autoria/configuração dos artefatos do
+  Hermes (skill, plugin, cron, config), não a revisão de código em geral.
+
+Leia [references/standards.md](references/standards.md) para caminhos,
+referência de comandos do CLI, seções de `config.yaml`, toolsets, regras de
+frontmatter de skill e fontes oficiais do Hermes Agent.

--- a/specialists/specsfy-specialist-hermes/agents/openai.yaml
+++ b/specialists/specsfy-specialist-hermes/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Specsfy · Hermes Agent"
+  short_description: "Autorar skills/plugins e operar o Hermes Agent"
+  default_prompt: "Use $specsfy-specialist-hermes para orientar esta tarefa com padrões e validação especializados do Hermes Agent."

--- a/specialists/specsfy-specialist-hermes/references/standards.md
+++ b/specialists/specsfy-specialist-hermes/references/standards.md
@@ -1,0 +1,144 @@
+# Padrões e referências do Hermes Agent
+
+Hermes Agent é o framework de agentes de IA open source da Nous Research que
+roda no terminal, desktop, plataformas de mensagem e IDEs. Esta referência
+consolida caminhos, comandos e regras de configuração/autoria verificáveis no
+runtime instalado.
+
+## Caminhos canônicos
+
+```text
+~/.hermes/config.yaml       Config principal (settings — nunca segredos)
+~/.hermes/.env              API keys e segredos SOMENTE (sob $HERMES_HOME)
+$HERMES_HOME/skills/        Skills instaladas
+$HERMES_HOME/plugins/       Plugins (estendem tools, providers, subcomandos)
+~/.hermes/skins/            Temas customizados
+~/.hermes/desktop-plugins/  Plugins de UI do app desktop
+~/.hermes/tui-widgets/      Widgets da TUI
+~/.hermes/state.db          Store canônico de sessões (SQLite + FTS5)
+~/.hermes/sessions/         Índice de roteamento do gateway + transcripts
+~/.hermes/logs/             Logs do gateway e de erros
+~/.hermes/auth.json         Tokens OAuth e pools de credenciais
+```
+
+Profiles usam `~/.hermes/profiles/<name>/` com o mesmo layout. Com profile
+ativo, resolver o home real por `$HERMES_HOME` — nunca hardcodar `~/.hermes`.
+
+## Instalação e diagnóstico
+
+```bash
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+hermes --version
+hermes setup          # wizard (model|tts|terminal|gateway|tools|agent)
+hermes model          # seletor de model/provider
+hermes doctor         # health check (--fix aplica correções)
+hermes login / logout # OAuth
+```
+
+## Referência de comandos do CLI
+
+- Chat: `hermes` (interativo), `hermes chat -q "..."` (one-shot),
+  `hermes --continue` (resume última sessão), `hermes --resume <id>`.
+- Config: `hermes config show|edit|get|set|unset|path|env-path|check|migrate`.
+  Ajuste SEMPRE por `hermes config set <seção>.<chave> <valor>`.
+- Tools/toolsets: `hermes tools` (curses), `hermes tools list`,
+  `hermes tools enable|disable <nome>`.
+- Skills: `hermes skills list|browse|search|inspect|install|check|update|
+  uninstall|publish|config`, `hermes skills tap add <repo>`.
+- MCP: `hermes mcp add <nome> (--url|--command)`, `hermes mcp list`,
+  `hermes mcp test <nome>`, `hermes mcp catalog|install|configure`, `serve`.
+- Gateway: `hermes gateway run|install|start|stop|restart|status|setup`
+  (20+ plataformas: Telegram, Discord, Slack, WhatsApp, iMessage, Signal,
+  Email, SMS, Matrix, ...).
+- Cron/webhooks: `hermes cron list|create <schedule>|edit|pause|resume|run|
+  remove|status`, `hermes webhook subscribe|list|remove|test`.
+- Sessões: `hermes sessions list|browse|rename|delete|export|prune|stats`.
+- Credenciais: `hermes auth`, `hermes auth add|list|remove|reset|status`
+  (pool com rotação automática).
+- Outros: `hermes desktop`/`gui`, `hermes dashboard`, `hermes proxy`,
+  `hermes profile list|create|use|show`, `hermes memory setup|status|off|reset`,
+  `hermes skin list|use|set`, `hermes pets`, `hermes logs [-f] [errors]`,
+  `hermes update`, `hermes --help`.
+
+## Seções de `config.yaml` (chaves mais usadas)
+
+| Seção | Chaves |
+| --- | --- |
+| model | default, provider, base_url, api_key, context_length, aliases |
+| agent | max_turns (90), tool_use_enforcement, service_tier, verify_on_stop |
+| terminal | backend (local/docker/ssh/...), cwd, timeout (180) |
+| compression | enabled, threshold (0.50), target_ratio (0.20) |
+| display | skin, interface (cli/tui), language, show_reasoning, show_cost |
+| approvals | mode (smart/manual/off), timeout, cron_mode |
+| stt | enabled, provider (local/groq/openai/mistral/...) |
+| tts | provider (edge/elevenlabs/openai/minimax/...) |
+| memory | memory_enabled, user_profile_enabled, provider, write_approval |
+| security | redact_secrets, tirith_enabled, website_blocklist |
+| delegation | model, provider, max_concurrent_children, max_spawn_depth |
+| checkpoints | enabled, max_snapshots (50) |
+| curator | enabled, consolidate, interval_hours, stale_after_days |
+
+`hermes config check` reporta seções ausentes de um config antigo.
+
+## Toolsets
+
+web, browser, terminal, file, code_execution, coding, computer_use, vision,
+image_gen, video, tts, skills, memory, session_search, delegation, cronjob,
+clarify, todo, kanban, safe, e integrações de serviço (spotify, discord, ...).
+Mudança de toolset faz efeito em `/reset` (sessão nova), nunca no meio da
+conversa, para preservar o prompt cache.
+
+## Arquivos de contexto do projeto
+
+Ordem de descoberta (primeiro que casa vence; só uma fonte por sessão):
+
+| Arquivo | Descoberta |
+| --- | --- |
+| `.hermes.md` / `HERMES.md` | sobe até a raiz git (herança raiz → pacote) |
+| `AGENTS.md` / `agents.md` | só cwd (portátil entre agentes) |
+| `CLAUDE.md` / `claude.md` | só cwd |
+| `.cursorrules` | só cwd |
+
+`SOUL.md` (em `$HERMES_HOME`) define identidade, não regras de projeto. Cada
+arquivo é limitado a 20.000 caracteres (head+tail quando excede). Todos passam
+pelo scanner de prompt injection antes do system prompt. `hermes --ignore-rules`
+desativa a injeção de contexto/regras para isolar problema.
+
+## Regras de autoria de SKILL.md (frontmatter)
+
+- Começa com `---` no byte 0; fecha com `\n---\n`; parseia como YAML mapping.
+- Campos: `name` (lowercase-hyphenated, ≤64 chars), `description` (≤60 chars,
+  uma frase, termina em ponto, sem marketing, sem repetir o name, sem `:` sem
+  aspas), `version` (0.1.0), `author`, `license`, `platforms`, e
+  `metadata.hermes.{tags, related_skills}`.
+- `author` credita o humano primeiro: `Nome (handle), Hermes Agent`.
+- `platforms` auditado pelo que a skill/scripts realmente invocam
+  (osascript→macos; apt/systemctl→linux; stdlib→todos), nunca copiado de outra.
+- Corpo: intro (o que faz/não faz/dependência), `## When to Use`,
+  `## Prerequisites`, `## How to Run`, `## Quick Reference`, `## Procedure`,
+  `## Pitfalls`, `## Verification`. Ferramentas do Hermes citadas por nome
+  (`terminal`, `read_file`, `patch`, `search_files`), não shell cru.
+- Material volumoso em `references/*.md`, `templates/`, `scripts/` — linkado por
+  caminho relativo, nunca inline. Nunca caminhos locais de máquina.
+
+## Invariantes rígidos
+
+- Segredos em `.env`, settings em `config.yaml`.
+- Nunca editar `config.yaml` à mão (usar `hermes config set`).
+- Caminhos de profile por `$HERMES_HOME`/`get_hermes_home()`.
+- Nunca quebrar o prompt cache: não mudar contexto passado, toolsets ou system
+  prompt no meio da conversa (só via `/reset`/nova sessão).
+- Alternância de roles de mensagem (nunca dois assistant/user seguidos).
+
+## Fontes oficiais
+
+- Documentação: https://hermes-agent.nousresearch.com/docs/
+- Repositório: https://github.com/NousResearch/hermes-agent
+- Instalador: https://hermes-agent.nousresearch.com/install.sh
+- CLI: https://hermes-agent.nousresearch.com/docs/reference/cli-commands
+- Configuração: https://hermes-agent.nousresearch.com/docs/user-guide/configuration
+- Providers: https://hermes-agent.nousresearch.com/docs/integrations/providers
+
+Confirme a versão instalada (`hermes --version`) e o `$HERMES_HOME` efetivo
+antes de usar qualquer comando ou chave — subcomandos de plugin só existem
+quando o plugin está instalado/ativo.

--- a/specialists/tests/test_catalogo_especialistas.py
+++ b/specialists/tests/test_catalogo_especialistas.py
@@ -18,6 +18,7 @@ EXPECTED_SKILLS = {
     "specsfy-specialist-docker-swarm",
     "specsfy-specialist-domain-modeling",
     "specsfy-specialist-gitflow",
+    "specsfy-specialist-hermes",
     "specsfy-specialist-laravel",
     "specsfy-specialist-merge-conflict-resolution",
     "specsfy-specialist-nextjs",


### PR DESCRIPTION
Adiciona o especialista `specsfy-specialist-hermes` ao catálogo.

## O que muda

- Novo specialist `specsfy-specialist-hermes` (`SKILL.md` + `agents/openai.yaml` + `references/standards.md`) cobrindo autoria de skills/plugins e operação do Hermes Agent: modelos, providers, gateway, cron, memória, toolsets e CLI.
- Entrada no `catalog.json` — categoria `platform`, tags `hermes/agents/automation/skills`, detecção por `.hermes.md`/`HERMES.md`.
- Nome adicionado ao `EXPECTED_SKILLS` do contrato de testes.
- Fronteira recíproca em `specsfy-specialist-code-review` (autorar/configurar artefatos do runtime vs. revisão de código em geral).
- Linha "agentes" no catálogo por domínio em `docs/user/specialists.md`.

## Validação

- `python3 -B -m unittest discover -s tests -p 'test_*.py'` → 7 testes OK
- `uv run --quiet --with behave behave tests/features --no-capture` → 6 cenários, 18 steps OK
- `catalog.json` parseia e a entrada do hermes está bem formada (categoria, tags, `detect.files`/`dependencies`).

## Nota

O conteúdo do specialist cita fontes oficiais do Hermes Agent (documentação e repositório NousResearch). A detecção é deliberadamente conservadora (`files` vazio de dependências), pois o Hermes é runtime de nível de usuário; o specialist também pode ser instalado sob demanda com `specsfy skills add specsfy-specialist-hermes`.
