### PR TITLE
fix(cli): resolve executável do PATH pelo PATHEXT no Windows

### DIFF
--- a/cli/src/prerequisites.ts
+++ b/cli/src/prerequisites.ts
@@ -19,6 +19,8 @@ interface CheckOptions {
   nodeVersion?: string;
   skillsOverride?: string;
   skillsLauncher?: string;
+  platform?: NodeJS.Platform;
+  pathext?: string;
 }
 
 /** Informa se a versão do runtime satisfaz o contrato do pacote. */
@@ -42,16 +44,18 @@ export async function resolveSkillsCommand(
   path = process.env.PATH ?? "",
   override = process.env.SPECSFY_SKILLS_CLI,
   launcher = process.argv[1],
+  platform: NodeJS.Platform = process.platform,
+  pathext = process.env.PATHEXT,
 ): Promise<string[] | undefined> {
   if (override) {
     const executable = resolve(override);
     return (await isExecutable(executable)) ? [executable] : undefined;
   }
-  const skills = await findExecutable("skills", path);
+  const skills = await findExecutable("skills", path, platform, pathext);
   if (skills) return [skills];
   const packaged = await resolvePackagedSkills(launcher);
   if (packaged) return [process.execPath, packaged];
-  const npx = await findExecutable("npx", path);
+  const npx = await findExecutable("npx", path, platform, pathext);
   return npx ? [npx, "--yes", "skills"] : undefined;
 }
 
@@ -62,12 +66,16 @@ export async function checkPrerequisites(
 ): Promise<PrerequisiteCheck[]> {
   const path = options.path ?? process.env.PATH ?? "";
   const nodeVersion = options.nodeVersion ?? process.versions.node;
-  const git = await findExecutable("git", path);
-  const npm = await findExecutable("npm", path);
+  const platform = options.platform ?? process.platform;
+  const pathext = options.pathext ?? process.env.PATHEXT;
+  const git = await findExecutable("git", path, platform, pathext);
+  const npm = await findExecutable("npm", path, platform, pathext);
   const skills = await resolveSkillsCommand(
     path,
     options.skillsOverride ?? process.env.SPECSFY_SKILLS_CLI,
     options.skillsLauncher ?? process.argv[1],
+    platform,
+    pathext,
   );
   const target = resolve(project);
   let projectOk = false;
@@ -129,13 +137,35 @@ export function assertPrerequisites(
   );
 }
 
-async function findExecutable(name: string, path: string): Promise<string | undefined> {
+async function findExecutable(
+  name: string,
+  path: string,
+  platform: NodeJS.Platform = process.platform,
+  pathext = process.env.PATHEXT,
+): Promise<string | undefined> {
   for (const directory of path.split(delimiter)) {
     if (!directory) continue;
-    const executable = join(directory, name);
-    if (await isExecutable(executable)) return executable;
+    for (const extension of executableExtensions(platform, pathext)) {
+      const executable = join(directory, `${name}${extension}`);
+      if (await isExecutable(executable)) return executable;
+    }
   }
   return undefined;
+}
+
+/**
+ * Sufixos que tornam um arquivo executável na plataforma corrente.
+ *
+ * No Windows um comando do PATH é um arquivo com extensão declarada em
+ * `PATHEXT`; procurar apenas pelo nome nunca encontra `git.exe`.
+ */
+function executableExtensions(platform: NodeJS.Platform, pathext: string | undefined): string[] {
+  if (platform !== "win32") return [""];
+  const declared = (pathext ?? ".COM;.EXE;.BAT;.CMD")
+    .split(";")
+    .map((item) => item.trim())
+    .filter(Boolean);
+  return ["", ...declared];
 }
 
 /** Localiza a dependência `skills` a partir do launcher instalado do Specsfy. */

--- a/cli/tests/prerequisites.test.ts
+++ b/cli/tests/prerequisites.test.ts
@@ -98,4 +98,54 @@ describe("pré-requisitos", () => {
       skills,
     ]);
   });
+  test("encontra executáveis com extensão do PATHEXT no Windows", async () => {
+    const root = await temporaryDirectory();
+    const bin = join(root, "bin");
+    const project = join(root, "project");
+    await mkdir(bin);
+    await mkdir(project);
+    for (const name of ["git.EXE", "skills.CMD", "npm"]) {
+      const executable = join(bin, name);
+      await writeFile(executable, "#!/bin/sh\nexit 0\n");
+      await chmod(executable, 0o755);
+    }
+
+    const checks = await checkPrerequisites(project, {
+      path: bin,
+      nodeVersion: "22.20.0",
+      platform: "win32",
+      pathext: ".COM;.EXE;.BAT;.CMD",
+    });
+
+    expect(checks.every(({ ok }) => ok)).toBe(true);
+    expect(checks.find(({ name }) => name === "git")?.command).toEqual([
+      join(bin, "git.EXE"),
+    ]);
+    expect(checks.find(({ name }) => name === "skills")?.command).toEqual([
+      join(bin, "skills.CMD"),
+    ]);
+    expect(checks.find(({ name }) => name === "npm")?.command).toEqual([
+      join(bin, "npm"),
+    ]);
+  });
+
+  test("não aceita sufixo do Windows em plataforma POSIX", async () => {
+    const root = await temporaryDirectory();
+    const bin = join(root, "bin");
+    await mkdir(bin);
+    const executable = join(bin, "git.EXE");
+    await writeFile(executable, "#!/bin/sh\nexit 0\n");
+    await chmod(executable, 0o755);
+
+    const checks = await checkPrerequisites(root, {
+      path: bin,
+      nodeVersion: "22.20.0",
+      platform: "linux",
+      skillsLauncher: "",
+    });
+
+    expect(checks.find(({ name }) => name === "git")).toMatchObject({
+      ok: false,
+    });
+  });
 });


### PR DESCRIPTION
## Problema

No Windows, `specsfy doctor` reporta `Git não encontrado no PATH` mesmo com o Git instalado e acessível:

```
OK      node     Node.js 22.20 ou mais recente; versão atual: 24.16.0
FALHA   git      Git não encontrado no PATH
OK      skills   skills CLI disponível
OK      npm      npm encontrado em C:\Program Files\nodejs\npm
OK      project  projeto legível e gravável
```

Com isso, `specsfy setup` recusa a execução e nenhum arquivo é criado:

```
erro: pré-requisitos ausentes:
- Git não encontrado no PATH
```

Como `assertPrerequisites(checks, ["node", "git", "skills", "project"])` é exigido em `setup` e `update` (`cli/src/cli.ts:74` e `:499`), o efeito prático é que o Specsfy não instala em nenhum projeto Windows.

## Causa

`findExecutable` procura apenas o nome exato dentro de cada diretório do PATH:

```ts
const executable = join(directory, name);
if (await isExecutable(executable)) return executable;
```

No Windows o executável do PATH é um arquivo com extensão declarada em `PATHEXT` (`git.exe`), então a busca por `git` nunca encontra nada. O `npm` passa por acaso: a instalação do Node deixa um script sem extensão ao lado do `npm.cmd`.

O `git` é realmente usado depois (`execFileAsync("git", …)` em `cli/src/installer.ts:566`), e ali funciona — o `child_process` resolve `PATHEXT` sozinho. O defeito está só na detecção.

## Correção

`findExecutable` passa a percorrer os sufixos de `PATHEXT`, mantendo o nome sem extensão como primeira tentativa. Isso preserva o comportamento POSIX e continua encontrando launchers sem extensão no Windows, como o próprio `npm`.

Plataforma e `PATHEXT` viraram parâmetros injetáveis (`CheckOptions.platform` e `CheckOptions.pathext`), no mesmo estilo de `path` e `nodeVersion` que já existiam, para que os dois caminhos sejam cobertos por teste em qualquer runner.

## Verificação

Dois testes novos em `cli/tests/prerequisites.test.ts`:

- `encontra executáveis com extensão do PATHEXT no Windows` — `git.EXE`, `skills.CMD` e `npm` sem extensão, todos resolvidos com `platform: "win32"`
- `não aceita sufixo do Windows em plataforma POSIX` — garante que `git.EXE` não passa a valer como `git` no Linux

Ambos passam. Depois da correção, o fluxo completo roda no Windows 11 (Node 24.16):

```
doctor        OK   git encontrado em C:\Program Files\Git\mingw64\bin\git.EXE
setup         OK   18 skills instaladas, .specsfy/ criado
progress      OK
skills detect OK   detectou next e supabase pelo package.json
skills add    OK   specsfy-specialist-nextjs instalado
```

## Sobre a suíte no Windows

`npm test` na `main` já falha em 13 testes neste ambiente, por motivos alheios a esta mudança — modos de arquivo POSIX (`0o600`, `0o755`, `0o111`), `symlink` sem developer mode, fixtures `#!/bin/sh` e o teste de TUI em terminal real. Com esta correção o resultado vai de `13 falhas / 79 passes` para `13 falhas / 81 passes`: as mesmas 13 falhas pré-existentes, mais os 2 testes novos. Nada regride.

Posso abrir uma issue separada com o detalhamento dessas 13, se for útil.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
