### PR TITLE
fix(skills): não trate a palavra portuguesa "todo" como marcador pendente

### DIFF
--- a/skills/specsfy-04-validate/scripts/validate_spec.mjs
+++ b/skills/specsfy-04-validate/scripts/validate_spec.mjs
@@ -51,7 +51,8 @@ if (!input || !existsSync(input)) {
   for (const kind of ["US", "FR", "NFR", "AC"]) if (!ids[kind].length) errors.push(`Nenhuma definição ${kind}-NNN encontrada.`);
   errors.push(...minimumBddErrors(body));
   if (status === "Complete" && /^\s*-\s+\[ \]\s+T\d{3,}/m.test(body)) errors.push("Status Complete não permite tarefas abertas na seção 14.");
-  if (/\b(?:TODO|TBD|FIXME)\b|\[NEEDS CLARIFICATION/im.test(body) && !(status === "Draft" && draft)) errors.push("Marcadores não resolvidos.");
+  // Sem o flag `i`: marcador é convenção maiúscula, e em português `todo` é palavra comum.
+  if (/\b(?:TODO|TBD|FIXME)\b|\[NEEDS CLARIFICATION/m.test(body) && !(status === "Draft" && draft)) errors.push("Marcadores não resolvidos.");
   const result = { path, format: field(body, "Formato"), slug, status, gates, counts: Object.fromEntries(Object.entries(ids).map(([key, value]) => [key, value.length])), errors, warnings };
   if (asJson) console.log(JSON.stringify(result, null, 2));
   else { console.log(`Spec: ${path}`); errors.forEach((error) => console.log(`ERRO: ${error}`)); console.log(errors.length ? "RESULTADO: NOT READY" : status === "Draft" ? "RESULTADO: VALID DRAFT" : "RESULTADO: READY"); }

--- a/skills/tests/test_unresolved_markers.py
+++ b/skills/tests/test_unresolved_markers.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+VALIDATE_SPEC = ROOT / "specsfy-04-validate" / "scripts" / "validate_spec.mjs"
+
+SECTIONS = [
+    "Problema e resultado",
+    "Research e esclarecimentos",
+    "Escopo e atores",
+    "Princípios e restrições do projeto",
+    "Histórias de usuário",
+    "Cenários BDD de aceite",
+    "Requisitos",
+    "Plano técnico",
+    "Modelo de dados",
+    "Interfaces e contratos",
+    "Estratégia TDD",
+    "Plano de testes e rastreabilidade",
+    "Validações",
+    "Tarefas",
+    "Ordem de execução",
+    "Dependências, riscos e suposições",
+    "Decisões",
+    "Definition of Done",
+]
+
+HEADER = (
+    "# Especificação integrada: Exemplo\n\n"
+    "| Campo | Valor |\n"
+    "| --- | --- |\n"
+    "| Formato | Specsfy/2.0 |\n"
+    "| ID | SPEC-0001 |\n"
+    "| Slug | 0001-exemplo |\n"
+    "| Status | Defined |\n"
+    "| Definition Gate | Passed |\n"
+    "| Plan Gate | Pending |\n"
+    "| Delivery Gate | Pending |\n\n"
+)
+
+
+def acceptance(ac_id: str) -> str:
+    covers = "US-001, FR-001, NFR-001"
+    tags = " ".join(f"@{item}" for item in covers.split(", "))
+    return (
+        f"#### {ac_id} — Contexto {ac_id}\n\n"
+        f"**Cobre**: {covers}\n\n"
+        "```gherkin\n"
+        f"{tags} @{ac_id}\n"
+        "Feature: Cobertura contextual\n\n"
+        f"  Scenario: Exemplo {ac_id}\n"
+        "    Given um estado conhecido\n"
+        "    When uma ação acontece\n"
+        "    Then um resultado é observado\n"
+        "```\n\n"
+    )
+
+
+def spec(body: str = "") -> str:
+    text = HEADER
+    for index, title in enumerate(SECTIONS, start=1):
+        text += f"### {index}. {title}\n\n"
+        if title == "Histórias de usuário":
+            text += "#### US-001 — História\n\n"
+        if title == "Cenários BDD de aceite":
+            text += "".join(acceptance(f"AC-00{item}") for item in (1, 2, 3))
+        if title == "Requisitos":
+            text += "- **FR-001**: O sistema deve responder.\n"
+            text += "- **NFR-001**: Responde em um segundo. **Verificação**: medição.\n\n"
+    return text + body
+
+
+class UnresolvedMarkerTests(unittest.TestCase):
+    def errors(self, text: str) -> list[str]:
+        with tempfile.TemporaryDirectory() as temporary:
+            path = Path(temporary) / "spec.md"
+            path.write_text(text, encoding="utf-8")
+            result = subprocess.run(
+                ["node", str(VALIDATE_SPEC), str(path), "--json"],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+            return json.loads(result.stdout)["errors"]
+
+    def test_baseline_spec_has_no_errors(self) -> None:
+        self.assertEqual(self.errors(spec()), [])
+
+    def test_portuguese_word_todo_is_not_a_marker(self) -> None:
+        """`todo` é palavra comum em português e não pode reprovar a spec."""
+        for phrase in ("A regra vale em todo caso.", "Todo ator recebe o aviso.", "Cobre todos os estados."):
+            with self.subTest(phrase=phrase):
+                self.assertEqual(self.errors(spec(phrase + "\n")), [])
+
+    def test_uppercase_markers_still_fail(self) -> None:
+        for marker in ("TODO: revisar", "TBD", "FIXME agora", "[NEEDS CLARIFICATION: escopo]"):
+            with self.subTest(marker=marker):
+                self.assertIn("Marcadores não resolvidos.", self.errors(spec(marker + "\n")))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problema

A checagem de marcadores não resolvidos em `validate_spec.mjs` é case-insensitive:

```js
if (/\b(?:TODO|TBD|FIXME)\b|\[NEEDS CLARIFICATION/im.test(body) && ...)
```

O flag `i` faz `TODO` casar com **`todo`**, que em português é palavra comum. Frases perfeitamente corretas reprovam a spec:

- "A regra vale em **todo** caso."
- "**Todo** ator recebe o aviso."
- "O gate roda em **todo** PR."

Como o Specsfy é um framework em português, isso atinge o caminho principal: qualquer spec sai de `Draft` e passa a reprovar na validação estrita, com a mensagem `Marcadores não resolvidos` apontando para prosa correta. A pessoa é levada a procurar um `TODO` que não existe.

## Reprodução

Numa spec real em português com `Status: Defined`:

```
$ node validate_spec.mjs spec.md
ERRO: Marcadores não resolvidos.
RESULTADO: NOT READY
```

Depois da correção, a mesma spec, sem nenhuma alteração de conteúdo:

```
$ node validate_spec.mjs spec.md
RESULTADO: READY
```

## Correção

Remover o flag `i`. Marcador pendente é convenção em maiúscula em toda a documentação do projeto, então a checagem não perde nada: `TODO`, `TBD`, `FIXME` e `[NEEDS CLARIFICATION` continuam detectados.

## Verificação

`skills/tests/test_unresolved_markers.py`, com três casos:

- a spec base valida sem erro;
- as frases com `todo`/`Todo` não reprovam;
- `TODO:`, `TBD`, `FIXME` e `[NEEDS CLARIFICATION` continuam reprovando.

RED antes da correção, GREEN depois:

```
# antes
FAIL: test_portuguese_word_todo_is_not_a_marker (phrase='A regra vale em todo caso.')
FAIL: test_portuguese_word_todo_is_not_a_marker (phrase='Todo ator recebe o aviso.')

# depois
Ran 3 tests — OK
```

A suíte de `skills/` sai de `76 testes / 14 falhas` para `79 testes / 14 falhas` no meu ambiente: as mesmas 14 falhas pré-existentes (Windows — modos de arquivo POSIX e symlink) e os 3 casos novos passando. Nada regride.

## Observação separada, não incluída neste PR

`skills/examples/Spec.md` declara `### 16. Dependências, falhas possíveis e suposições`, mas `validate_spec.mjs` exige o heading `Dependências, riscos e suposições` — que é o que o `templates/Spec.md` usa. A fixture não passa na própria validação, nem com `--allow-draft`:

```
$ node validate_spec.mjs skills/examples/Spec.md --allow-draft
ERRO: Heading obrigatório ausente: Dependências, riscos e suposições.
RESULTADO: NOT READY
```

Não mexi porque não sei se o texto da fixture é deliberado. Se preferir, mando junto ou em PR separado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
