### PR TITLE
fix(skills): corrige path com espaço em setup_context.mjs

### DIFF
--- a/skills/specsfy-setup/scripts/setup_context.mjs
+++ b/skills/specsfy-setup/scripts/setup_context.mjs
@@ -3,9 +3,10 @@
 import { existsSync } from "node:fs";
 import { readFile, mkdir, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { syncSpecKitContext } from "./sync_speckit_context.mjs";
 
-const START = "<!-- specsfy:framework:start -->"; const END = "<!-- specsfy:framework:end -->"; const skillRoot = resolve(dirname(new URL(import.meta.url).pathname), "..", "..");
+const START = "<!-- specsfy:framework:start -->"; const END = "<!-- specsfy:framework:end -->"; const skillRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const args = process.argv.slice(2); const project = resolve(args.includes("--project") ? args[args.indexOf("--project") + 1] : process.cwd());
 async function json(path) { try { const value = JSON.parse(await readFile(path, "utf8")); return value && typeof value === "object" ? value : {}; } catch { return {}; } }
 async function template(name, tokens) { const candidates = [join(project, ".specsfy", "templates", "custom", name), join(project, ".specsfy", "templates", name), join(skillRoot, "templates", name)]; const path = candidates.find(existsSync); if (!path) throw new Error(`template não encontrado: ${join(project, ".specsfy", "templates", name)}; execute \`specsfy install\``); let content = await readFile(path, "utf8"); for (const [token, value] of Object.entries(tokens)) { if (!content.includes(token)) throw new Error(`token obrigatório ausente em ${path}: ${token}`); content = content.replaceAll(token, value); } const unresolved = [...new Set(content.match(/\{\{[A-Z0-9_]+\}\}/g) ?? [])]; if (unresolved.length) throw new Error(`tokens não preenchidos em ${path}: ${unresolved.join(", ")}`); return content; }


### PR DESCRIPTION
## Bug

`skills/specsfy-setup/scripts/setup_context.mjs` calcula `skillRoot` com:

```js
const skillRoot = resolve(dirname(new URL(import.meta.url).pathname), "..", "..");
```

`new URL(...).pathname` retorna o caminho **URL-encoded** (espaços viram `%20`). Como `dirname`/`resolve`/`readFile` do Node não decodificam isso, qualquer projeto instalado sob um caminho com espaço (comum no macOS, ex. `~/.../PROJETOS ATIVOS/...`) quebra com:

```
Error: ENOENT: no such file or directory, open '.../PROJETOS%20ATIVOS/.../references/framework-instructions.md'
```

## Reprodução

1. Instale o CLI num projeto cujo caminho absoluto contenha um espaço.
2. Rode `specsfy setup --project .` (ou diretamente `node .agents/skills/specsfy-setup/scripts/setup_context.mjs --project .`).
3. O script falha ao tentar ler `references/framework-instructions.md`.

## Causa

Os outros três scripts do monorepo que resolvem o próprio diretório (`specsfy-01-inbox/scripts/capturar_inbox.mjs`, `specsfy-02-backlog/scripts/iniciar_backlog.mjs`, `specsfy-03-specify/scripts/iniciar_spec.mjs`) já usam corretamente `fileURLToPath(import.meta.url)`. Só `specsfy-setup/scripts/setup_context.mjs` ficou com o padrão antigo `new URL(import.meta.url).pathname`.

## Fix

Troca para `fileURLToPath(import.meta.url)`, consistente com os demais scripts. Validado localmente: após o ajuste, `PROJECT.md`, `STACK.md`, `RULES.md` e `DATABASE.md` são gerados normalmente num projeto sob caminho com espaço.

Issue original: EducamundoBR/specsfy#1