### PR TITLE
fix(validate): reconhece testes .mjs e para de ler "todo" como marcador pendente

### DIFF
--- a/skills/specsfy-04-validate/scripts/validate_spec.mjs
+++ b/skills/specsfy-04-validate/scripts/validate_spec.mjs
@@ -100,7 +100,7 @@ if (!input || !existsSync(input)) {
   for (const kind of ["US", "FR", "NFR", "AC"]) if (!ids[kind].length) errors.push(`Nenhuma definição ${kind}-NNN encontrada.`);
   errors.push(...minimumBddErrors(body));
   if (status === "Complete" && /^\s*-\s+\[ \]\s+T\d{3,}/m.test(body)) errors.push("Status Complete não permite tarefas abertas na seção 14.");
-  if (/\b(?:TODO|TBD|FIXME)\b|\[NEEDS CLARIFICATION/im.test(body) && !(status === "Draft" && draft)) errors.push("Marcadores não resolvidos.");
+  if (/\b(?:TODO|TBD|FIXME)\b|\[NEEDS CLARIFICATION/m.test(body) && !(status === "Draft" && draft)) errors.push("Marcadores não resolvidos.");
   errors.push(...interfaceErrors(body, status));
   const result = { path, format: field(body, "Formato"), slug, status, gates, counts: Object.fromEntries(Object.entries(ids).map(([key, value]) => [key, value.length])), errors, warnings };
   if (asJson) console.log(JSON.stringify(result, null, 2));

--- a/skills/specsfy-06-tdd-bdd/scripts/check_traceability.mjs
+++ b/skills/specsfy-06-tdd-bdd/scripts/check_traceability.mjs
@@ -5,7 +5,7 @@ import { readFile, readdir } from "node:fs/promises";
 import { extname, join, relative, resolve } from "node:path";
 
 const skipped = new Set([".agents", ".git", ".hg", ".svn", ".venv", "build", "coverage", "dist", "examples", "fixture", "fixtures", "node_modules", "research", "samples", "target", "vendor"]);
-const extensions = new Set([".cs", ".go", ".java", ".js", ".jsx", ".kt", ".php", ".py", ".rb", ".rs", ".ts", ".tsx"]);
+const extensions = new Set([".cjs", ".cs", ".go", ".java", ".js", ".jsx", ".kt", ".mjs", ".php", ".py", ".rb", ".rs", ".ts", ".tsx"]);
 async function walk(directory) { const files = []; for (const item of await readdir(directory, { withFileTypes: true })) { if (skipped.has(item.name)) continue; const path = join(directory, item.name); if (item.isDirectory()) files.push(...await walk(path)); else files.push(path); } return files; }
 const args = process.argv.slice(2); const positional = args.filter((arg) => !arg.startsWith("--") && !/^\d+$/.test(arg)); const [spec, root] = positional;
 const option = (name, fallback) => args.includes(name) ? args[args.indexOf(name) + 1] : fallback;

--- a/tests/test_cobertura_minima_spec.py
+++ b/tests/test_cobertura_minima_spec.py
@@ -91,6 +91,56 @@ class MinimumCoverageIntegrationTests(unittest.TestCase):
 
             self.assertEqual(0, green.returncode, green.stdout + green.stderr)
 
+
+    def test_traceability_scans_mjs_and_cjs_test_files(self) -> None:
+        """Um pacote Node sem `"type": "module"` precisa usar `.mjs` para ESM."""
+        with tempfile.TemporaryDirectory() as temporary:
+            root = Path(temporary)
+            spec = root / "specs/specs/0001-example/spec.md"
+            test = root / "tests/example.test.mjs"
+            spec.parent.mkdir(parents=True)
+            test.parent.mkdir(parents=True)
+            spec.write_text(
+                "#### US-001 — Example\n"
+                "#### AC-001 — Example\n"
+                "#### AC-002 — Example\n"
+                "#### AC-003 — Example\n"
+                "- **FR-001**: Example.\n"
+                "- **NFR-001**: Example. **Verificação**: teste.\n",
+                encoding="utf-8",
+            )
+            marker = "US-001 FR-001 NFR-001"
+            test.write_text(
+                f"// SPECSFY: {marker} AC-001\n"
+                "test('first', () => {});\n"
+                f"// SPECSFY: {marker} AC-002\n"
+                "test('second', () => {});\n"
+                f"// SPECSFY: {marker} AC-003\n"
+                "test('third', () => {});\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                ["node", str(TRACE), str(spec), str(root), "--json"],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+            self.assertIn('"files_scanned": 1', result.stdout)
+
+    def test_pending_markers_ignore_the_portuguese_word_todo(self) -> None:
+        """`todo` é palavra comum em pt-BR e não pode ser lida como marcador."""
+        portuguese = (
+            "#### US-001 — História\n"
+            "- **PR-001**: todo texto visível é escrito em Português do Brasil.\n"
+        )
+        marker = portuguese + "- **FR-002**: TODO definir o comportamento.\n"
+
+        self.assertNotIn("Marcadores não resolvidos.", self.validate(portuguese))
+        self.assertIn("Marcadores não resolvidos.", self.validate(marker))
+
     def test_template_framework_and_docs_publish_same_minimum(self) -> None:
         template = (SKILLS / "templates/Spec.md").read_text(encoding="utf-8")
         framework = (SKILLS / "Spec.md").read_text(encoding="utf-8")


### PR DESCRIPTION
Corrige os dois defeitos relatados em #21. São duas mudanças de uma linha cada, mais dois testes de regressão.

Fique à vontade para rejeitar ou pedir outra abordagem — o defeito 2 em especial admite soluções diferentes, e listei as alternativas na issue.

## 1. `check_traceability.mjs` — reconhecer `.mjs` e `.cjs`

```diff
-const extensions = new Set([".cs", ".go", ".java", ".js", ".jsx", ".kt", ".php", ".py", ".rb", ".rs", ".ts", ".tsx"]);
+const extensions = new Set([".cjs", ".cs", ".go", ".java", ".js", ".jsx", ".kt", ".mjs", ".php", ".py", ".rb", ".rs", ".ts", ".tsx"]);
```

Um pacote Node que não declara `"type": "module"` precisa usar `.mjs` para arquivos ESM: um `.js` seria interpretado como CommonJS e qualquer `import` falharia. Sem essas extensões, o auditor não enxerga nenhum teste desses pacotes.

Num monorepo com 41 arquivos `.test.mjs` no frontend, executados por `node --test test/*.test.mjs`, o resultado era:

```
Rastreabilidade: 9/28 IDs cobertos em 230 arquivos de teste.
RESULTADO: GAPS
```

Os 9 reconhecidos eram exatamente os `.spec.ts` do backend. Depois da correção:

```
Rastreabilidade: 28/28 IDs cobertos em 272 arquivos de teste.
RESULTADO: OK
```

Também `OK` com `--full-chain`, e `verify_acceptance.mjs` passou a retornar `QA: PASSED`.

## 2. `validate_spec.mjs` — não ler "todo" como marcador pendente

```diff
-if (/\b(?:TODO|TBD|FIXME)\b|\[NEEDS CLARIFICATION/im.test(body) && ...
+if (/\b(?:TODO|TBD|FIXME)\b|\[NEEDS CLARIFICATION/m.test(body) && ...
```

A flag `i` fazia `\bTODO\b` casar com a palavra portuguesa **"todo"**. Frases legítimas derrubavam a validação:

- `**PR-005**: todo texto visível é Português do Brasil, sem UUID, enum técnico ou identificador interno.`
- `**NFR-003**: A versão exibida, a versão enviada e a versão persistida devem ser idênticas em todo cadastro concluído.`

A mensagem `Marcadores não resolvidos` aponta para o lugar errado, e a pessoa vai caçar um `TODO` que não existe. Como o framework exige artefatos em pt-BR, a colisão é recorrente.

Optei por remover a flag: `TODO`, `TBD` e `FIXME` são convencionalmente escritos em caixa alta, inclusive no template do próprio Specsfy. Isso preserva a detecção de marcadores reais e elimina o falso positivo. `[NEEDS CLARIFICATION` já aparece em caixa alta no template, então segue detectado.

Se preferir manter `i` para `TBD`/`FIXME`, ou exigir `TODO:` com delimitador, é uma troca fácil — só avisar.

## Testes

Dois casos novos em `tests/test_cobertura_minima_spec.py`, no estilo do arquivo:

- `test_traceability_scans_mjs_and_cjs_test_files` — spec com três ACs marcados num `.test.mjs`; espera `returncode 0` e o arquivo efetivamente varrido.
- `test_pending_markers_ignore_the_portuguese_word_todo` — verifica que "todo" em prosa não acusa erro e que um `TODO` real continua acusando.

Verificação local:

```
python3 -m unittest tests.test_cobertura_minima_spec
Ran 5 tests ... OK
```

Com as correções revertidas e os testes mantidos: `FAILED (failures=2)` — os dois casos novos são sensíveis ao defeito.

Suíte completa: `Ran 112 tests, FAILED (failures=3)`. As três falhas são `test_monorepo`, `test_documentacao_monorepo` e `test_ebook_usuario`, que exigem que o `origin` seja `promovaweb/specsfy` e que o manifesto do ebook esteja atual. Elas ocorrem igualmente na árvore limpa do fork, antes de qualquer alteração minha.

## Ambiente

`specsfy 0.8.1`, Node v24.19.0, Linux. Detectado num monorepo Turborepo com Next.js 16 e NestJS 11.
