### PR TITLE
fix(skills): regra de marcadores não dispara mais em prosa portuguesa

### DIFF
--- a/cli/tests/validate-spec-markers.test.ts
+++ b/cli/tests/validate-spec-markers.test.ts
@@ -1,0 +1,68 @@
+/** Regressões da regra de marcadores não resolvidos do specsfy-04-validate. */
+import { execFileSync } from "node:child_process";
+import { writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "vitest";
+import { temporaryDirectory } from "./helpers.js";
+
+const script = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "../../skills/specsfy-04-validate/scripts/validate_spec.mjs",
+);
+
+const ERRO = "Marcadores não resolvidos.";
+
+/** Cabeçalho mínimo: a regra de marcadores roda mesmo com outros erros. */
+function spec(corpo: string): string {
+  return [
+    "# Especificação integrada: teste",
+    "",
+    "| Campo | Valor |",
+    "| --- | --- |",
+    "| Formato | Specsfy/2.0 |",
+    "| ID | SPEC-0001 |",
+    "| Slug | 0001-teste |",
+    "| Status | Defined |",
+    "| Definition Gate | Passed |",
+    "| Plan Gate | Pending |",
+    "| Delivery Gate | Pending |",
+    "",
+    corpo,
+    "",
+  ].join("\n");
+}
+
+async function validar(corpo: string): Promise<string> {
+  const arquivo = join(await temporaryDirectory(), "spec.md");
+  await writeFile(arquivo, spec(corpo), "utf8");
+  try {
+    return execFileSync("node", [script, arquivo], { encoding: "utf8" });
+  } catch (error) {
+    // O validador sai com código 1 quando há erros; a saída é o que interessa.
+    return String((error as { stdout?: string }).stdout ?? "");
+  }
+}
+
+describe("marcadores não resolvidos", () => {
+  test("acusa TODO, TBD, FIXME e NEEDS CLARIFICATION", async () => {
+    for (const marcador of ["TODO", "TBD", "FIXME", "[NEEDS CLARIFICATION: x]"]) {
+      expect(await validar(`- ${marcador} resolver isto`)).toContain(ERRO);
+    }
+  });
+
+  test("não acusa a palavra portuguesa todo", async () => {
+    expect(await validar("- A captura é obrigatória em todo documento.")).not.toContain(ERRO);
+  });
+
+  test("não acusa todo dentro de método, onde o acento cria fronteira de palavra", async () => {
+    // `\b` do JavaScript quebra em caractere não-ASCII: o `é` de "Método" abre
+    // fronteira antes de "todo". A linha vem do próprio template gerenciado,
+    // então toda spec em português nascia reprovando a validação estrita.
+    expect(await validar("- [Método/rota ou evento, autenticação, request.]")).not.toContain(ERRO);
+  });
+
+  test("não acusa outras palavras acentuadas que terminam em todo", async () => {
+    expect(await validar("- O símbolo e o método são úteis; o critério, também.")).not.toContain(ERRO);
+  });
+});

--- a/skills/specsfy-04-validate/scripts/validate_spec.mjs
+++ b/skills/specsfy-04-validate/scripts/validate_spec.mjs
@@ -100,7 +100,12 @@ if (!input || !existsSync(input)) {
   for (const kind of ["US", "FR", "NFR", "AC"]) if (!ids[kind].length) errors.push(`Nenhuma definição ${kind}-NNN encontrada.`);
   errors.push(...minimumBddErrors(body));
   if (status === "Complete" && /^\s*-\s+\[ \]\s+T\d{3,}/m.test(body)) errors.push("Status Complete não permite tarefas abertas na seção 14.");
-  if (/\b(?:TODO|TBD|FIXME)\b|\[NEEDS CLARIFICATION/im.test(body) && !(status === "Draft" && draft)) errors.push("Marcadores não resolvidos.");
+  // Sem a flag `i`: os marcadores são maiúsculos por convenção, e `\b` do
+  // JavaScript quebra em caractere não-ASCII. Com ela, o `é` de "Método" abria
+  // fronteira de palavra e `\btodo\b` casava dentro da própria palavra — a
+  // linha `[Método/rota ...]` do template gerenciado fazia toda spec em
+  // português reprovar a validação estrita sem nenhum marcador real.
+  if (/\b(?:TODO|TBD|FIXME)\b|\[NEEDS CLARIFICATION/m.test(body) && !(status === "Draft" && draft)) errors.push("Marcadores não resolvidos.");
   errors.push(...interfaceErrors(body, status));
   const result = { path, format: field(body, "Formato"), slug, status, gates, counts: Object.fromEntries(Object.entries(ids).map(([key, value]) => [key, value.length])), errors, warnings };
   if (asJson) console.log(JSON.stringify(result, null, 2));


### PR DESCRIPTION
## Problema

O `\b` do JavaScript quebra em qualquer caractere não-ASCII. Com a flag `i`, o `é` de **"Método"** abre uma fronteira de palavra e `\bTODO\b` casa **dentro da palavra** — e a linha que dispara vem do próprio template gerenciado, seção 10:

```
- [Método/rota ou evento, autenticação, request, response, erros e versionamento.]
```

Consequência: **toda spec escrita em português nascia reprovando a validação estrita** (`ERRO: Marcadores não resolvidos.`) sem ter nenhum marcador real. Prosa comum como "em todo documento" também dispara.

## Correção

Remover a flag `i` da regra em `skills/specsfy-04-validate/scripts/validate_spec.mjs`. Os marcadores são maiúsculos por convenção (`TODO`, `TBD`, `FIXME`, `[NEEDS CLARIFICATION`), então nada legítimo deixa de ser detectado.

A variante Python (`example/.../validate_spec.py`) já está correta: não usa `re.IGNORECASE` nessa regra, e o `\b` do Python é Unicode-aware.

## Testes

O script não tinha nenhum teste; este PR adiciona `cli/tests/validate-spec-markers.test.ts` com quatro regressões cobrindo os dois sentidos — marcadores reais continuam reprovando, e "todo", "método" e outras palavras acentuadas deixam de reprovar. Suíte do CLI após o rebase sobre a v0.11.0: 4/4 verdes no arquivo novo.

Encontrado em uso real: a SPEC-0001 e a SPEC-0002 de um projeto consumidor reprovavam a validação estrita apenas por este falso positivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)