### PR TITLE
feat(skills): adiciona specsfy-08-operational-audit para auditoria pós-feature

### DIFF
--- a/docs/user/skills/specsfy-08-operational-audit.md
+++ b/docs/user/skills/specsfy-08-operational-audit.md
@@ -1,0 +1,58 @@
+# Auditar a efetivação com `specsfy-08-operational-audit`
+
+Use esta skill depois que uma SPEC estiver em `completed` para verificar se a
+implementação ainda deixou alguma ação operacional diretamente causada pela
+entrega.
+
+Ela responde a uma pergunta específica:
+
+> A implementação terminou. Existe algo operacional que esta SPEC tornou
+> necessário e que ainda falta efetivar?
+
+A skill começa delimitando o escopo real da SPEC por rastreabilidade, tarefas,
+commits e diff. Ela não presume que todo o working tree ou toda alteração recente
+pertença à feature.
+
+Depois aplica causalidade antes de criar qualquer pendência. Uma ação só conta
+quando a própria SPEC criou a necessidade e essa ação é necessária para o
+comportamento funcionar no ambiente aplicável. Dívidas antigas de infraestrutura
+ficam separadas e não inflam a contagem da feature.
+
+## O que ela verifica
+
+A auditoria cobre migrations, banco/backfill, seeds, cache/config, assets,
+env/secrets, workers, processos persistentes, infraestrutura, deploy/release,
+serviços externos, permissões, storage, observabilidade, backup/rollback,
+compatibilidade de release, smoke tests e outras ações externas.
+
+Os estados são:
+
+- `NÃO NECESSÁRIO`;
+- `JÁ CONCLUÍDO`;
+- `PENDENTE`;
+- `REQUER AUTORIZAÇÃO`;
+- `INCERTO — PROCESSO NÃO DOCUMENTADO`.
+
+`INCERTO` não significa apenas “produção é desconhecida”. Primeiro precisa
+existir uma necessidade causal comprovada pela SPEC.
+
+## Limite de segurança
+
+A skill é somente de auditoria. Ela não executa deploy, migrations, seeds,
+restarts, rebuilds, limpeza de cache ou mudanças em banco, configuração,
+infraestrutura ou serviços externos.
+
+Quando encontra uma ação operacional real, ela relata evidência, risco e próxima
+ação. A execução deve ser encaminhada depois para a skill ou especialista
+apropriado, com autorização explícita quando a ação for sensível.
+
+## Exemplo
+
+Uma SPEC sem migration, env nova ou mudança de infraestrutura não recebe
+pendências artificiais nessas categorias. Se ela alterou assets e o build já foi
+validado, isso não prova que os artefatos foram publicados; a auditoria só cria
+pendência de publicação quando existir promoção causalmente necessária para um
+ambiente aplicável.
+
+O objetivo é reduzir falsos positivos e separar com clareza `Delivery Gate:
+Passed` de qualquer trabalho operacional que realmente permaneça fora do código.

--- a/docs/user/skills/specsfy-08-operational-audit.md
+++ b/docs/user/skills/specsfy-08-operational-audit.md
@@ -1,13 +1,13 @@
 # Auditar a efetivação com `specsfy-08-operational-audit`
 
 Use esta skill depois que uma SPEC estiver em `completed` para verificar se a
-implementação ainda deixou alguma ação operacional diretamente causada pela
-entrega.
+implementação ainda deixou alguma ação operacional, técnica ou de validação
+diretamente causada pela entrega.
 
 Ela responde a uma pergunta específica:
 
-> A implementação terminou. Existe algo operacional que esta SPEC tornou
-> necessário e que ainda falta efetivar?
+> A implementação terminou. Existe algo adicional que esta SPEC tornou
+> necessário e que ainda falta efetivar ou validar?
 
 A skill começa delimitando o escopo real da SPEC por rastreabilidade, tarefas,
 commits e diff. Ela não presume que todo o working tree ou toda alteração recente
@@ -15,15 +15,24 @@ pertença à feature.
 
 Depois aplica causalidade antes de criar qualquer pendência. Uma ação só conta
 quando a própria SPEC criou a necessidade e essa ação é necessária para o
-comportamento funcionar no ambiente aplicável. Dívidas antigas de infraestrutura
-ficam separadas e não inflam a contagem da feature.
+comportamento funcionar ou ser corretamente validado no ambiente aplicável.
+Dívidas antigas de infraestrutura ficam separadas e não inflam a contagem da
+feature.
 
 ## O que ela verifica
 
 A auditoria cobre migrations, banco/backfill, seeds, cache/config, assets,
 env/secrets, workers, processos persistentes, infraestrutura, deploy/release,
-serviços externos, permissões, storage, observabilidade, backup/rollback,
-compatibilidade de release, smoke tests e outras ações externas.
+serviços externos, permissões, storage, revalidação automatizada pós-ação,
+validação manual em runtime, observabilidade, backup/rollback, compatibilidade
+de release, smoke tests e outras ações externas.
+
+Também diferencia explicitamente:
+
+- build validado de interface funcional em runtime;
+- servidor local/dev de deploy;
+- `git push` de promoção para ambiente;
+- comando operacional bem-sucedido de validação efetiva da feature.
 
 Os estados são:
 
@@ -36,23 +45,56 @@ Os estados são:
 `INCERTO` não significa apenas “produção é desconhecida”. Primeiro precisa
 existir uma necessidade causal comprovada pela SPEC.
 
+## Revalidação depois de ações operacionais
+
+A skill não considera uma ação operacional concluída apenas porque o comando
+retornou sucesso. Quando aplicável, ela exige um plano de validação proporcional
+ao impacto.
+
+Por exemplo, uma migration pode exigir:
+
+1. confirmar o estado da migration;
+2. executar testes focais;
+3. executar a suíte completa quando houver risco transversal;
+4. validar build/lint/type checks quando relacionados;
+5. executar smoke test e confirmar o comportamento funcional.
+
+Do mesmo modo, deploy, restart, reload ou publicação de assets podem exigir
+health check, fluxo principal, falha controlada, autorização/isolamento e
+observação de logs.
+
+## Validação manual em runtime
+
+Quando a SPEC altera interface, rota, formulário, autenticação, autorização,
+navegação ou outro comportamento visível, a auditoria verifica se a aplicação
+já foi validada em ambiente executável.
+
+Essa validação pode confirmar renderização, carregamento de assets, interação
+principal, erros controlados, autorização, isolamento, responsividade, foco e
+teclado, conforme os critérios da SPEC.
+
+Se a validação já está registrada nas evidências da entrega, ela é tratada como
+`JÁ CONCLUÍDO` e não deve ser repetida sem causa nova.
+
 ## Limite de segurança
 
 A skill é somente de auditoria. Ela não executa deploy, migrations, seeds,
 restarts, rebuilds, limpeza de cache ou mudanças em banco, configuração,
 infraestrutura ou serviços externos.
 
-Quando encontra uma ação operacional real, ela relata evidência, risco e próxima
-ação. A execução deve ser encaminhada depois para a skill ou especialista
-apropriado, com autorização explícita quando a ação for sensível.
+Quando encontra uma ação real, ela relata evidência, risco, ordem, validação
+pós-execução e próxima ação. A execução deve ser encaminhada depois para a skill
+ou especialista apropriado, com autorização explícita quando a ação for
+sensível.
 
 ## Exemplo
 
 Uma SPEC sem migration, env nova ou mudança de infraestrutura não recebe
 pendências artificiais nessas categorias. Se ela alterou assets e o build já foi
-validado, isso não prova que os artefatos foram publicados; a auditoria só cria
-pendência de publicação quando existir promoção causalmente necessária para um
-ambiente aplicável.
+validado, isso não prova que a interface foi testada em runtime nem que os
+artefatos foram publicados; a auditoria cria pendência apenas quando existir uma
+necessidade causal ainda não satisfeita.
 
 O objetivo é reduzir falsos positivos e separar com clareza `Delivery Gate:
-Passed` de qualquer trabalho operacional que realmente permaneça fora do código.
+Passed` de qualquer validação ou trabalho operacional que realmente permaneça
+fora da implementação concluída.

--- a/skills/specsfy-08-operational-audit/SKILL.md
+++ b/skills/specsfy-08-operational-audit/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: specsfy-08-operational-audit
+description: "Use depois que uma SPEC chegar a completed para auditar se existe alguma ação operacional adicional diretamente causada pela entrega. Delimita o escopo da SPEC, aplica causalidade, evita falsos positivos e não executa operações sem autorização."
+---
+
+# Auditar a efetivação operacional de uma feature concluída
+
+Use esta skill somente depois que a SPEC estiver concluída no fluxo do Specsfy.
+Ela não reabre gates, não implementa código e não substitui deploy, delivery
+engineering ou especialistas de infraestrutura.
+
+## Objetivo
+
+Responder com precisão:
+
+> A implementação da SPEC terminou. Existe alguma ação operacional diretamente
+> causada por esta SPEC que ainda precisa ser realizada?
+
+A auditoria não procura melhorias gerais, dívidas antigas ou boas práticas
+abstratas. Ela identifica apenas o delta operacional causal da entrega.
+
+## Modo de interação
+
+Modo de interação: sem perguntas durante a auditoria. Se o processo operacional
+necessário não estiver documentado, registre a incerteza no relatório em vez de
+inventar uma resposta. Qualquer execução operacional posterior exige pedido ou
+autorização explícita da pessoa.
+
+## Passo 0 — delimitar o escopo da SPEC
+
+Antes de avaliar qualquer categoria, determine quais mudanças pertencem à SPEC.
+Use, nesta ordem:
+
+1. artefatos e rastreabilidade registrados pelo Specsfy;
+2. a SPEC concluída e suas tarefas/evidências;
+3. commits explicitamente associados à entrega;
+4. diff desses commits contra a base anterior;
+5. branch da feature contra a branch-base, quando aplicável.
+
+Não presuma que todo o working tree, todo o branch ou toda alteração recente
+pertence à SPEC. Separe mudanças anteriores, paralelas ou locais não relacionadas.
+Se o escopo não puder ser delimitado com confiança, declare a limitação e não
+atribua arquivos à SPEC por inferência silenciosa.
+
+## Regras absolutas
+
+Durante esta skill, não execute nenhuma ação operacional. Não altere arquivos,
+não reabra a SPEC, não implemente código, não faça commit ou push, não faça
+deploy, não execute migrations, seeds, restart, rebuild, limpeza de cache,
+alteração de banco, variáveis, infraestrutura ou serviços externos.
+
+Comandos de inspeção só podem ser usados quando forem comprovadamente somente
+leitura e sem efeitos colaterais. Não consulte produção, infraestrutura remota
+ou serviços externos apenas para confirmar estado sem autorização explícita.
+
+## Regra de causalidade
+
+Uma ação só é pendente desta feature quando ambas forem verdadeiras:
+
+1. a SPEC criou ou alterou algo que exige essa ação;
+2. a ação é necessária para que o comportamento implementado funcione no
+   ambiente de destino.
+
+Boa prática geral não é pendência da feature. Exemplos:
+
+- SPEC sem migration → migrations = `NÃO NECESSÁRIO`;
+- SPEC sem variável nova → env/secrets = `NÃO NECESSÁRIO`;
+- SPEC sem alteração de Dockerfile/stack → infraestrutura = `NÃO NECESSÁRIO`
+  para esta SPEC.
+
+## Regra de evidência
+
+Baseie conclusões apenas em evidência concreta da SPEC, tarefas, commits, diff,
+migrations, seeders, configuração, scripts, lockfiles, frontend, jobs, CI/CD e
+documentação factual do projeto.
+
+Não invente comandos como `npm install`, `npm ci`, `docker build`,
+`docker stack deploy`, `php artisan migrate`, `cache:clear`, `route:cache`,
+`config:cache` ou restart de serviço sem evidência de que esse é o procedimento
+real do projeto.
+
+## Estados permitidos
+
+Use exatamente um estado por categoria:
+
+| Estado | Definição |
+| --- | --- |
+| `NÃO NECESSÁRIO` | a SPEC não criou necessidade operacional nessa categoria |
+| `JÁ CONCLUÍDO` | a SPEC exigia a ação e há evidência de que ela foi realizada |
+| `PENDENTE` | a SPEC exige a ação e ela ainda não foi realizada |
+| `REQUER AUTORIZAÇÃO` | a necessidade está comprovada e a execução modifica ambiente, dados ou infraestrutura |
+| `INCERTO — PROCESSO NÃO DOCUMENTADO` | a necessidade está comprovada, mas o procedimento real não está documentado |
+
+Nunca use `INCERTO` apenas porque o funcionamento geral de produção é desconhecido.
+Primeiro deve existir uma necessidade causal criada pela SPEC.
+
+## Categorias
+
+Avalie cada categoria somente além de `NÃO NECESSÁRIO` quando houver evidência
+causal concreta:
+
+| # | Categoria | Evidência que pode torná-la necessária |
+| --- | --- | --- |
+| 1 | Migrations | migration criada/alterada, schema, constraint ou índice alterado |
+| 2 | Banco/backfill/dados | backfill, transformação, atualização, recálculo ou reprocessamento |
+| 3 | Seeds | seeder, lookup, role/permissão inicial ou dado obrigatório novo |
+| 4 | Cache/config | mudança que comprovadamente exige reconstrução/recarga operacional |
+| 5 | Assets/frontend | CSS/JS/assets processados por build |
+| 6 | Env/secrets | variável, secret, token, endpoint, flag, chave ou credencial nova/alterada |
+| 7 | Workers/queues/scheduler | job, listener, queue, consumer, scheduler ou cron alterado |
+| 8 | Processos persistentes | Octane, Horizon, RoadRunner, Swoole, WebSocket, daemon ou processo residente afetado |
+| 9 | Infraestrutura | Dockerfile, compose, stack, k8s, proxy, volumes, rede, storage ou CI/CD alterado |
+| 10 | Deploy/release | promoção para ambiente-alvo comprovadamente necessária |
+| 11 | Serviços externos | API, webhook, OAuth, SaaS, DNS, SMTP, pagamento, storage ou integração externa |
+| 12 | Permissões/IAM | configuração operacional/externa de acesso |
+| 13 | Storage/filesystem | diretório, symlink, volume, bucket, mount ou permissão nova |
+| 14 | Observabilidade pós-ativação | somente se houver ativação/deploy efetivamente pendente |
+| 15 | Backup/rollback | mudança destrutiva, migration relevante, transformação de dados ou risco operacional específico |
+| 16 | Compatibilidade de release | schema/código incompatíveis, payload de fila, API, sessão, cache ou rolling deploy |
+| 17 | Smoke test | somente se houver ativação/deploy pendente |
+| 18 | Outras ações externas | feature flag, cadastro externo, sincronização, reprocessamento ou ativação manual |
+
+## Regra específica para deploy/release
+
+Primeiro determine se há evidência de que a SPEC deve ser promovida para algum
+ambiente. Diferencie implementação/versionamento do objetivo de ativação em
+staging ou produção.
+
+- `JÁ CONCLUÍDO`: há evidência de que a versão está ativa no ambiente-alvo;
+- `PENDENTE`: ambiente e processo são conhecidos e a versão ainda não foi promovida;
+- `REQUER AUTORIZAÇÃO`: deploy comprovadamente necessário e dependente de autorização;
+- `INCERTO — PROCESSO NÃO DOCUMENTADO`: promoção necessária, mas mecanismo real ausente;
+- `NÃO NECESSÁRIO`: o objetivo atual era implementar/versionar e não há obrigação comprovada de promover agora.
+
+`git push` não significa deploy, mas também não assuma que toda SPEC precisa de
+deploy imediato.
+
+## Assets
+
+Se a SPEC alterou assets, diferencie build validado de artefato publicado. Um
+`npm run build` verde prova o build naquele contexto; não prova que os assets já
+estão ativos em um ambiente. Só crie pendência de publicação quando a promoção
+for causalmente necessária e houver ambiente-alvo aplicável.
+
+## Dívidas globais
+
+Backup global, criptografia, observabilidade, hardening ou documentação de deploy
+preexistentes não entram na contagem da feature. Se forem relevantes, registre
+em seção separada `PENDÊNCIAS GLOBAIS NÃO CRIADAS PELA SPEC`. Só bloqueiam a
+feature quando houver relação causal comprovada.
+
+## Não duplicar causas
+
+Uma causa raiz não deve virar várias pendências. Se um único processo de release
+não documentado explica dúvidas sobre assets, rollout e smoke test, conte a
+causa uma vez e registre as demais como consequências dependentes.
+
+## Contagem e consistência
+
+Conte os estados diretamente da tabela final e confira novamente antes de
+responder. O resumo deve corresponder exatamente ao checklist.
+
+## Relatório final
+
+### A. RESUMO
+
+Informe caminho da SPEC, status, como o escopo foi delimitado, commits
+considerados, implementação, operacionalização, contagens de `PENDENTE`,
+`REQUER AUTORIZAÇÃO` e `INCERTO`, bloqueio confirmado e causa principal.
+
+### B. CHECKLIST
+
+Produza tabela com `Categoria | Estado | Evidência causal | Próxima ação` para
+as 18 categorias.
+
+### C. AÇÕES REALMENTE PENDENTES
+
+Somente itens `PENDENTE` ou `REQUER AUTORIZAÇÃO`. Para cada um, informe ação,
+evidência causal, ambiente, risco, comando somente se comprovado pelo projeto,
+validação e rollback quando aplicável.
+
+### D. INCERTEZAS REAIS
+
+Somente itens `INCERTO — PROCESSO NÃO DOCUMENTADO`. Informe necessidade
+comprovada, informação faltante, onde obtê-la e qual decisão depende dela.
+
+### E. PENDÊNCIAS GLOBAIS NÃO CRIADAS PELA SPEC
+
+Opcional e fora das contagens da feature.
+
+### F. ORDEM DE EXECUÇÃO
+
+Somente se houver `PENDENTE` ou `REQUER AUTORIZAÇÃO`. Use a ordem real das
+dependências, nunca uma sequência genérica.
+
+### G. AUTORIZAÇÃO
+
+Liste apenas ações comprovadamente necessárias que dependem de autorização.
+
+### H. CONCLUSÃO
+
+Escolha exatamente uma:
+
+1. `FEATURE COMPLETA — NENHUMA AÇÃO OPERACIONAL ADICIONAL NECESSÁRIA`
+2. `FEATURE IMPLEMENTADA — AÇÕES OPERACIONAIS PENDENTES`
+3. `FEATURE IMPLEMENTADA — PROCESSO OPERACIONAL PRECISA SER IDENTIFICADO`
+4. `FEATURE IMPLEMENTADA — BLOQUEADA PARA ATIVAÇÃO`
+5. `FEATURE NÃO ESTÁ REALMENTE CONCLUÍDA`
+
+## Limite da skill
+
+Esta skill audita e relata. Quando houver ação operacional comprovada, encaminhe
+a execução para a skill/especialista apropriado somente após autorização
+explícita. Não transforme auditoria em deploy automático.

--- a/skills/specsfy-08-operational-audit/SKILL.md
+++ b/skills/specsfy-08-operational-audit/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: specsfy-08-operational-audit
-description: "Use depois que uma SPEC chegar a completed para auditar se existe alguma ação operacional adicional diretamente causada pela entrega. Delimita o escopo da SPEC, aplica causalidade, evita falsos positivos e não executa operações sem autorização."
+description: "Use depois que uma SPEC chegar a completed para auditar ações adicionais diretamente causadas pela entrega, incluindo revalidação automatizada, build e validação manual em runtime. Delimita escopo, aplica causalidade, evita falsos positivos e não executa operações sem autorização."
 ---
 
-# Auditar a efetivação operacional de uma feature concluída
+# Auditar a efetivação pós-feature
 
 Use esta skill somente depois que a SPEC estiver concluída no fluxo do Specsfy.
 Ela não reabre gates, não implementa código e não substitui deploy, delivery
@@ -13,18 +13,25 @@ engineering ou especialistas de infraestrutura.
 
 Responder com precisão:
 
-> A implementação da SPEC terminou. Existe alguma ação operacional diretamente
-> causada por esta SPEC que ainda precisa ser realizada?
+> A implementação da SPEC terminou. Existe alguma ação operacional, técnica ou
+> de validação diretamente causada por esta SPEC que ainda precisa ser realizada
+> para que a feature esteja efetivamente pronta e validada?
 
-A auditoria não procura melhorias gerais, dívidas antigas ou boas práticas
-abstratas. Ela identifica apenas o delta operacional causal da entrega.
+A auditoria distingue:
+
+1. implementação concluída;
+2. validação técnica concluída;
+3. validação funcional em runtime concluída;
+4. operacionalização concluída;
+5. deploy/ativação, quando fizer parte do objetivo real.
+
+Ela não procura melhorias gerais, dívidas antigas ou boas práticas abstratas.
 
 ## Modo de interação
 
-Modo de interação: sem perguntas durante a auditoria. Se o processo operacional
-necessário não estiver documentado, registre a incerteza no relatório em vez de
-inventar uma resposta. Qualquer execução operacional posterior exige pedido ou
-autorização explícita da pessoa.
+Modo de interação: sem perguntas durante a auditoria. Se um processo necessário
+não estiver documentado, registre a incerteza em vez de inventar uma resposta.
+Qualquer execução posterior exige pedido ou autorização explícita da pessoa.
 
 ## Passo 0 — delimitar o escopo da SPEC
 
@@ -44,10 +51,11 @@ atribua arquivos à SPEC por inferência silenciosa.
 
 ## Regras absolutas
 
-Durante esta skill, não execute nenhuma ação operacional. Não altere arquivos,
-não reabra a SPEC, não implemente código, não faça commit ou push, não faça
-deploy, não execute migrations, seeds, restart, rebuild, limpeza de cache,
-alteração de banco, variáveis, infraestrutura ou serviços externos.
+Durante esta skill, não execute nenhuma ação. Não altere arquivos, não reabra a
+SPEC, não implemente código, não faça commit ou push, não faça deploy, não
+execute migrations ou seeds, não reinicie processos, não faça rebuild
+operacional, não limpe caches, não altere banco, variáveis, infraestrutura,
+serviços externos ou artefatos publicados.
 
 Comandos de inspeção só podem ser usados quando forem comprovadamente somente
 leitura e sem efeitos colaterais. Não consulte produção, infraestrutura remota
@@ -58,26 +66,29 @@ ou serviços externos apenas para confirmar estado sem autorização explícita.
 Uma ação só é pendente desta feature quando ambas forem verdadeiras:
 
 1. a SPEC criou ou alterou algo que exige essa ação;
-2. a ação é necessária para que o comportamento implementado funcione no
-   ambiente de destino.
+2. a ação é necessária para que o comportamento implementado funcione ou seja
+   corretamente validado no ambiente aplicável.
 
 Boa prática geral não é pendência da feature. Exemplos:
 
 - SPEC sem migration → migrations = `NÃO NECESSÁRIO`;
 - SPEC sem variável nova → env/secrets = `NÃO NECESSÁRIO`;
-- SPEC sem alteração de Dockerfile/stack → infraestrutura = `NÃO NECESSÁRIO`
-  para esta SPEC.
+- SPEC sem alteração de Dockerfile/stack → infraestrutura = `NÃO NECESSÁRIO`;
+- SPEC sem interface, rota ou fluxo visível → validação manual em runtime pode
+  ser `NÃO NECESSÁRIO`.
 
 ## Regra de evidência
 
 Baseie conclusões apenas em evidência concreta da SPEC, tarefas, commits, diff,
-migrations, seeders, configuração, scripts, lockfiles, frontend, jobs, CI/CD e
-documentação factual do projeto.
+migrations, seeders, configuração, scripts, package manager, lockfiles,
+frontend, jobs, CI/CD, scripts de desenvolvimento, build, deploy e documentação
+factual do projeto.
 
-Não invente comandos como `npm install`, `npm ci`, `docker build`,
-`docker stack deploy`, `php artisan migrate`, `cache:clear`, `route:cache`,
-`config:cache` ou restart de serviço sem evidência de que esse é o procedimento
-real do projeto.
+Não invente comandos como `npm install`, `npm ci`, `npm run build`,
+`npm run dev`, `php artisan serve`, `docker build`, `docker stack deploy`,
+`php artisan migrate`, `php artisan db:seed`, `cache:clear`, `route:cache`,
+`config:cache`, `queue:restart` ou restart de serviço sem evidência de que esse é
+o procedimento real do projeto.
 
 ## Estados permitidos
 
@@ -85,9 +96,9 @@ Use exatamente um estado por categoria:
 
 | Estado | Definição |
 | --- | --- |
-| `NÃO NECESSÁRIO` | a SPEC não criou necessidade operacional nessa categoria |
-| `JÁ CONCLUÍDO` | a SPEC exigia a ação e há evidência de que ela foi realizada |
-| `PENDENTE` | a SPEC exige a ação e ela ainda não foi realizada |
+| `NÃO NECESSÁRIO` | a SPEC não criou necessidade adicional nessa categoria |
+| `JÁ CONCLUÍDO` | a SPEC exigia a ação/validação e há evidência de que ela foi realizada |
+| `PENDENTE` | a SPEC exige a ação/validação e ela ainda não foi realizada |
 | `REQUER AUTORIZAÇÃO` | a necessidade está comprovada e a execução modifica ambiente, dados ou infraestrutura |
 | `INCERTO — PROCESSO NÃO DOCUMENTADO` | a necessidade está comprovada, mas o procedimento real não está documentado |
 
@@ -114,46 +125,136 @@ causal concreta:
 | 11 | Serviços externos | API, webhook, OAuth, SaaS, DNS, SMTP, pagamento, storage ou integração externa |
 | 12 | Permissões/IAM | configuração operacional/externa de acesso |
 | 13 | Storage/filesystem | diretório, symlink, volume, bucket, mount ou permissão nova |
-| 14 | Observabilidade pós-ativação | somente se houver ativação/deploy efetivamente pendente |
-| 15 | Backup/rollback | mudança destrutiva, migration relevante, transformação de dados ou risco operacional específico |
-| 16 | Compatibilidade de release | schema/código incompatíveis, payload de fila, API, sessão, cache ou rolling deploy |
-| 17 | Smoke test | somente se houver ativação/deploy pendente |
-| 18 | Outras ações externas | feature flag, cadastro externo, sincronização, reprocessamento ou ativação manual |
+| 14 | Validação automatizada pós-ação | ação operacional alterou estado e exige nova prova automatizada |
+| 15 | Validação manual em runtime | interface, rota ou comportamento visível precisa ser provado executando a aplicação |
+| 16 | Observabilidade pós-ativação | somente se houver ativação/deploy efetivamente pendente |
+| 17 | Backup/rollback | mudança destrutiva, migration relevante, transformação de dados ou risco operacional específico |
+| 18 | Compatibilidade de release | schema/código incompatíveis, payload de fila, API, sessão, cache ou rolling deploy |
+| 19 | Smoke test | somente se houver runtime/deploy/ativação a validar |
+| 20 | Outras ações externas | feature flag, cadastro externo, sincronização, reprocessamento ou ativação manual |
 
-## Regra específica para deploy/release
+## Migrations
+
+Se a SPEC criou ou alterou migrations, determine qual migration, ambiente,
+dependência funcional, risco de lock/perda de dados, compatibilidade, ordem com
+deploy, necessidade de backup e validação posterior. Se não houve migration:
+`NÃO NECESSÁRIO`. Não peça `migrate:status` apenas por precaução.
+
+## Revalidação após migration
+
+Migration aplicada com sucesso não prova a feature. Quando aplicável, a sequência
+é:
+
+```text
+migration aplicada
+→ confirmar estado da migration
+→ testes focais
+→ suíte completa
+→ build/lint/type checks, quando relacionados
+→ smoke test
+→ confirmação funcional
+```
+
+Se o projeto possui suíte automatizada completa aplicável e a ação alterou
+schema, prefira recomendar também a suíte completa, além dos testes focais. Use
+somente comandos comprovados pelo projeto.
+
+## Testes automatizados pós-ação
+
+Determine se alguma ação operacional exige reexecução de testes, por exemplo
+migration, seed, configuração, dependência, restart, rebuild de assets ou deploy.
+Diferencie teste focal, suíte relacionada e suíte completa. Não considere a ação
+concluída apenas porque o comando operacional retornou código zero.
+
+## Assets e build
+
+Se a SPEC alterou frontend, diferencie source alterado, build validado, artefato
+gerado, publicação necessária e ambiente que precisa carregá-lo. Build verde não
+prova interface funcional em runtime nem publicação no ambiente.
+
+Só recomende `npm run build` ou equivalente quando o próprio projeto comprovar o
+comando. O build deve provar compilação e geração dos artefatos esperados.
+
+## Validação manual em runtime
+
+Se a SPEC criou ou alterou interface, formulário, rota, autenticação,
+autorização, navegação, fluxo HTTP, assets ou comportamento visível, determine
+se é necessária validação manual em ambiente executável.
+
+Quando aplicável, confirme:
+
+- aplicação inicia sem erro;
+- rota principal responde;
+- tela renderiza corretamente;
+- assets carregam;
+- interação principal funciona;
+- erro/estado alternativo relevante funciona;
+- autorização e isolamento funcionam, quando aplicável;
+- logout funciona, quando aplicável;
+- não há erro visual ou de runtime relevante;
+- responsividade, foco e teclado, quando fizerem parte do aceite.
+
+Se essa validação já está registrada na SPEC, use `JÁ CONCLUÍDO` e não peça
+repetição sem causa nova.
+
+## Diferenciar runtime local de deploy
+
+Servidor local/dev serve para validar a feature; não é deploy. Staging/produção
+é ambiente operacional e pode exigir release, rollout, restart e smoke test.
+Não trate `php artisan serve`, `npm run dev` ou equivalente como promoção de
+produção.
+
+Se a validação manual exige subir a aplicação, determine o mecanismo real pelos
+scripts/documentação do projeto. Se a necessidade é comprovada, mas o mecanismo
+não está documentado, use `INCERTO — PROCESSO NÃO DOCUMENTADO`.
+
+## Cache/config
+
+Não recomende limpeza ou rebuild genérico. Só considere necessário quando houver
+evidência de que o cache é usado, a SPEC exige reconstrução e o processo não faz
+isso automaticamente. Avalie impacto em rate limiting, sessão, locks, filas e
+dados operacionais antes de sugerir qualquer ação.
+
+## Deploy/release
 
 Primeiro determine se há evidência de que a SPEC deve ser promovida para algum
-ambiente. Diferencie implementação/versionamento do objetivo de ativação em
-staging ou produção.
+ambiente. Diferencie implementação/versionamento, validação local e ativação em
+staging/produção.
 
 - `JÁ CONCLUÍDO`: há evidência de que a versão está ativa no ambiente-alvo;
 - `PENDENTE`: ambiente e processo são conhecidos e a versão ainda não foi promovida;
 - `REQUER AUTORIZAÇÃO`: deploy comprovadamente necessário e dependente de autorização;
 - `INCERTO — PROCESSO NÃO DOCUMENTADO`: promoção necessária, mas mecanismo real ausente;
-- `NÃO NECESSÁRIO`: o objetivo atual era implementar/versionar e não há obrigação comprovada de promover agora.
+- `NÃO NECESSÁRIO`: o objetivo atual era implementar/versionar/validar e não há obrigação comprovada de promover agora.
 
-`git push` não significa deploy, mas também não assuma que toda SPEC precisa de
-deploy imediato.
+`git push`, build e servidor local não significam deploy.
 
-## Assets
+## Revalidação após deploy/restart/build
 
-Se a SPEC alterou assets, diferencie build validado de artefato publicado. Um
-`npm run build` verde prova o build naquele contexto; não prova que os assets já
-estão ativos em um ambiente. Só crie pendência de publicação quando a promoção
-for causalmente necessária e houver ambiente-alvo aplicável.
+Se houver deploy, restart, reload, publicação de assets ou rebuild, determine
+health check, smoke test, happy path, falha controlada, autorização/isolation,
+logs e rollback quando aplicável. Não considere o release validado apenas porque
+o rollout terminou tecnicamente.
+
+## Smoke test
+
+Quando houver runtime/deploy a validar, proponha smoke tests mínimos ligados aos
+ACs críticos: health, fluxo principal, falha controlada, autenticação,
+autorização, isolamento, rota/formulário novo ou integração alterada. Não repita
+a suíte completa como smoke test.
 
 ## Dívidas globais
 
 Backup global, criptografia, observabilidade, hardening ou documentação de deploy
 preexistentes não entram na contagem da feature. Se forem relevantes, registre
-em seção separada `PENDÊNCIAS GLOBAIS NÃO CRIADAS PELA SPEC`. Só bloqueiam a
-feature quando houver relação causal comprovada.
+em `PENDÊNCIAS GLOBAIS NÃO CRIADAS PELA SPEC`. Só bloqueiam a feature quando
+houver relação causal comprovada.
 
 ## Não duplicar causas
 
 Uma causa raiz não deve virar várias pendências. Se um único processo de release
-não documentado explica dúvidas sobre assets, rollout e smoke test, conte a
-causa uma vez e registre as demais como consequências dependentes.
+não documentado explica dúvidas sobre assets, rollout e smoke test, conte a causa
+uma vez e registre as demais como consequências dependentes.
 
 ## Contagem e consistência
 
@@ -165,19 +266,21 @@ responder. O resumo deve corresponder exatamente ao checklist.
 ### A. RESUMO
 
 Informe caminho da SPEC, status, como o escopo foi delimitado, commits
-considerados, implementação, operacionalização, contagens de `PENDENTE`,
-`REQUER AUTORIZAÇÃO` e `INCERTO`, bloqueio confirmado e causa principal.
+considerados, implementação, validação automatizada, validação manual em
+runtime, operacionalização, contagens de `PENDENTE`, `REQUER AUTORIZAÇÃO` e
+`INCERTO`, bloqueio confirmado e causa principal.
 
 ### B. CHECKLIST
 
 Produza tabela com `Categoria | Estado | Evidência causal | Próxima ação` para
-as 18 categorias.
+as 20 categorias.
 
 ### C. AÇÕES REALMENTE PENDENTES
 
 Somente itens `PENDENTE` ou `REQUER AUTORIZAÇÃO`. Para cada um, informe ação,
 evidência causal, ambiente, risco, comando somente se comprovado pelo projeto,
-validação e rollback quando aplicável.
+dependências, ordem, rollback, validação pós-execução, comando de teste somente
+se comprovado e critério de sucesso.
 
 ### D. INCERTEZAS REAIS
 
@@ -191,24 +294,43 @@ Opcional e fora das contagens da feature.
 ### F. ORDEM DE EXECUÇÃO
 
 Somente se houver `PENDENTE` ou `REQUER AUTORIZAÇÃO`. Use a ordem real das
-dependências, nunca uma sequência genérica.
+dependências e inclua as validações entre as ações; nunca use sequência genérica.
 
 ### G. AUTORIZAÇÃO
 
-Liste apenas ações comprovadamente necessárias que dependem de autorização.
+Liste apenas ações comprovadamente necessárias que dependem de autorização,
+com ambiente, risco, efeito e validação posterior.
 
-### H. CONCLUSÃO
+### H. PLANO DE VALIDAÇÃO PÓS-AÇÃO
+
+Se houver ação pendente, produza tabela com `Ação | Validação obrigatória |
+Comando comprovado | Critério de sucesso`. Inclua, quando aplicável, estado da
+migration, testes focais, suíte completa, lint, análise estática, type checks,
+build, runtime, teste manual, smoke test, health check, logs e critérios de
+rollback.
+
+### I. VALIDAÇÃO MANUAL DA FEATURE
+
+Se a SPEC possuir interface ou fluxo visível, informe ambiente recomendado,
+como iniciar a aplicação somente se comprovado, URL/rota, estados, comportamento
+esperado e evidência que deve ser registrada. Se já houve validação manual na
+SPEC, use `JÁ CONCLUÍDO`.
+
+### J. CONCLUSÃO
 
 Escolha exatamente uma:
 
-1. `FEATURE COMPLETA — NENHUMA AÇÃO OPERACIONAL ADICIONAL NECESSÁRIA`
-2. `FEATURE IMPLEMENTADA — AÇÕES OPERACIONAIS PENDENTES`
-3. `FEATURE IMPLEMENTADA — PROCESSO OPERACIONAL PRECISA SER IDENTIFICADO`
-4. `FEATURE IMPLEMENTADA — BLOQUEADA PARA ATIVAÇÃO`
-5. `FEATURE NÃO ESTÁ REALMENTE CONCLUÍDA`
+1. `FEATURE COMPLETA — NENHUMA AÇÃO OU VALIDAÇÃO ADICIONAL NECESSÁRIA`
+2. `FEATURE IMPLEMENTADA — VALIDAÇÕES PÓS-IMPLEMENTAÇÃO PENDENTES`
+3. `FEATURE IMPLEMENTADA — AÇÕES OPERACIONAIS PENDENTES`
+4. `FEATURE IMPLEMENTADA — PROCESSO OPERACIONAL PRECISA SER IDENTIFICADO`
+5. `FEATURE IMPLEMENTADA — BLOQUEADA PARA ATIVAÇÃO`
+6. `FEATURE NÃO ESTÁ REALMENTE CONCLUÍDA`
 
 ## Limite da skill
 
-Esta skill audita e relata. Quando houver ação operacional comprovada, encaminhe
-a execução para a skill/especialista apropriado somente após autorização
-explícita. Não transforme auditoria em deploy automático.
+Esta skill audita e relata. Não considere build verde como prova de interface
+funcional, servidor local como deploy, `git push` como deploy ou comando técnico
+bem-sucedido como prova suficiente de efetivação. Toda ação relevante deve ter
+validação proporcional ao impacto. Quando houver ação comprovada, encaminhe a
+execução para a skill/especialista apropriado somente após autorização explícita.

--- a/skills/specsfy-08-operational-audit/agents/openai.yaml
+++ b/skills/specsfy-08-operational-audit/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Specsfy - 08 - Auditoria operacional"
+  short_description: "Audita ações operacionais após a feature"
+  default_prompt: "Use $specsfy-08-operational-audit depois que uma SPEC estiver em completed para delimitar o escopo da entrega e identificar somente ações operacionais causalmente necessárias, sem executá-las."

--- a/skills/specsfy-08-operational-audit/agents/openai.yaml
+++ b/skills/specsfy-08-operational-audit/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Specsfy - 08 - Auditoria operacional"
-  short_description: "Audita ações operacionais após a feature"
-  default_prompt: "Use $specsfy-08-operational-audit depois que uma SPEC estiver em completed para delimitar o escopo da entrega e identificar somente ações operacionais causalmente necessárias, sem executá-las."
+  short_description: "Audita efetivação e validação após a feature"
+  default_prompt: "Use $specsfy-08-operational-audit depois que uma SPEC estiver em completed para delimitar o escopo da entrega, identificar somente ações ou validações causalmente necessárias e distinguir build, runtime local e deploy, sem executar operações."

--- a/skills/tests/test_operational_audit.py
+++ b/skills/tests/test_operational_audit.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL = ROOT / "specsfy-08-operational-audit" / "SKILL.md"
+OPENAI = ROOT / "specsfy-08-operational-audit" / "agents/openai.yaml"
+
+
+class OperationalAuditSkillTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.contract = SKILL.read_text(encoding="utf-8")
+        cls.metadata = OPENAI.read_text(encoding="utf-8")
+
+    def test_skill_declares_post_feature_scope_and_read_only_boundary(self) -> None:
+        self.assertIn("name: specsfy-08-operational-audit", self.contract)
+        self.assertIn("depois que a SPEC estiver concluída", self.contract)
+        self.assertIn("não execute nenhuma ação operacional", self.contract.lower())
+        self.assertIn("Passo 0 — delimitar o escopo da SPEC", self.contract)
+
+    def test_skill_requires_causality_before_operational_debt(self) -> None:
+        self.assertIn("Regra de causalidade", self.contract)
+        self.assertIn("a SPEC criou ou alterou algo que exige essa ação", self.contract)
+        self.assertIn("INCERTO — PROCESSO NÃO DOCUMENTADO", self.contract)
+        self.assertIn("Não duplicar causas", self.contract)
+
+    def test_skill_separates_global_debt_from_feature_debt(self) -> None:
+        self.assertIn("PENDÊNCIAS GLOBAIS NÃO CRIADAS PELA SPEC", self.contract)
+        self.assertIn("não entram na contagem da feature", self.contract)
+
+    def test_skill_exposes_discovery_metadata(self) -> None:
+        self.assertIn('display_name: "Specsfy - 08 - Auditoria operacional"', self.metadata)
+        self.assertIn("$specsfy-08-operational-audit", self.metadata)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/skills/tests/test_operational_audit.py
+++ b/skills/tests/test_operational_audit.py
@@ -18,7 +18,7 @@ class OperationalAuditSkillTests(unittest.TestCase):
     def test_skill_declares_post_feature_scope_and_read_only_boundary(self) -> None:
         self.assertIn("name: specsfy-08-operational-audit", self.contract)
         self.assertIn("depois que a SPEC estiver concluída", self.contract)
-        self.assertIn("não execute nenhuma ação operacional", self.contract.lower())
+        self.assertIn("não execute nenhuma ação", self.contract.lower())
         self.assertIn("Passo 0 — delimitar o escopo da SPEC", self.contract)
 
     def test_skill_requires_causality_before_operational_debt(self) -> None:
@@ -30,6 +30,24 @@ class OperationalAuditSkillTests(unittest.TestCase):
     def test_skill_separates_global_debt_from_feature_debt(self) -> None:
         self.assertIn("PENDÊNCIAS GLOBAIS NÃO CRIADAS PELA SPEC", self.contract)
         self.assertIn("não entram na contagem da feature", self.contract)
+
+    def test_skill_requires_post_action_revalidation(self) -> None:
+        self.assertIn("Revalidação após migration", self.contract)
+        self.assertIn("Testes automatizados pós-ação", self.contract)
+        self.assertIn("suíte completa", self.contract)
+        self.assertIn("não considere a ação concluída", self.contract.lower())
+
+    def test_skill_distinguishes_build_runtime_and_deploy(self) -> None:
+        self.assertIn("Validação manual em runtime", self.contract)
+        self.assertIn("Diferenciar runtime local de deploy", self.contract)
+        self.assertIn("Build verde não prova interface funcional em runtime", self.contract)
+        self.assertIn("git push`, build e servidor local não significam deploy", self.contract)
+
+    def test_skill_reports_extended_validation_contract(self) -> None:
+        self.assertIn("20 categorias", self.contract)
+        self.assertIn("PLANO DE VALIDAÇÃO PÓS-AÇÃO", self.contract)
+        self.assertIn("VALIDAÇÃO MANUAL DA FEATURE", self.contract)
+        self.assertIn("FEATURE IMPLEMENTADA — VALIDAÇÕES PÓS-IMPLEMENTAÇÃO PENDENTES", self.contract)
 
     def test_skill_exposes_discovery_metadata(self) -> None:
         self.assertIn('display_name: "Specsfy - 08 - Auditoria operacional"', self.metadata)


### PR DESCRIPTION
## Motivação

Depois que uma SPEC chega a `completed`, o Specsfy comprova código, testes, evidências e gates, mas ainda pode existir uma responsabilidade diferente: **há alguma ação operacional, técnica ou de validação diretamente causada por esta SPEC que ainda precisa ser efetivada?**

O caso prático mostrou que não basta perguntar apenas por migration/deploy. Também é importante distinguir:

- migration aplicada de feature realmente revalidada;
- build verde de interface funcional em runtime;
- servidor local/dev de deploy;
- `git push` de promoção para ambiente;
- ação operacional concluída tecnicamente de ação efetivamente validada.

## Proposta

Adiciona a nova skill base proposta:

`specsfy-08-operational-audit`

A skill roda **depois da conclusão da SPEC** e é somente de auditoria. Ela:

- delimita primeiro o escopo real da SPEC por rastreabilidade, tarefas, commits e diff;
- exige causalidade antes de classificar qualquer ação como pendente;
- distingue `NÃO NECESSÁRIO`, `JÁ CONCLUÍDO`, `PENDENTE`, `REQUER AUTORIZAÇÃO` e `INCERTO — PROCESSO NÃO DOCUMENTADO`;
- não inventa comandos operacionais quando o processo real do projeto não está documentado;
- separa dívidas globais preexistentes das ações realmente criadas pela feature;
- evita contar a mesma causa raiz várias vezes;
- audita migrations, banco/backfill, seeds, cache/config, assets, env/secrets, workers, processos persistentes, infraestrutura, deploy/release, serviços externos, permissões/IAM, storage/filesystem, observabilidade, backup/rollback, compatibilidade, smoke tests e outras ações externas;
- inclui revalidação automatizada pós-ação;
- inclui validação manual em runtime para interface, rota ou fluxo visível;
- diferencia explicitamente build, runtime local/dev e deploy;
- não executa deploy, migrations, seeds, restart, rebuild, limpeza de cache ou alterações externas.

## Revalidação pós-ação

A skill não considera uma ação operacional concluída apenas porque o comando retornou sucesso.

Exemplo para migration, quando aplicável:

`migration aplicada → confirmar estado → testes focais → suíte completa → smoke test → confirmação funcional`

Também pode exigir build/lint/type checks quando relacionados à mudança.

## Validação manual em runtime

Para interface, formulário, rota, autenticação, autorização, navegação ou outro comportamento visível, a auditoria verifica se a aplicação já foi validada em ambiente executável.

Ela diferencia:

- servidor local/dev para validação;
- staging/produção como ativação operacional.

`php artisan serve`, `npm run dev` ou equivalente não são tratados como deploy.

## Limite de responsabilidade

A skill **audita e relata**. Quando encontra uma ação comprovada, a execução deve ser encaminhada posteriormente para a skill/especialista apropriado e continua sujeita às autorizações existentes do framework.

Isso preserva a distinção:

`Delivery Gate: Passed` ≠ `toda ação/validação externa já foi efetivada`.

## Integração proposta

Esta primeira versão permanece **independente e opt-in** para reduzir o acoplamento com o fluxo central durante a revisão. Ela não altera ainda `specsfy-07-implement` nem força handoff automático após `completed`.

Se a responsabilidade for aceita pelos mantenedores, a evolução natural é decidir se a skill entra no catálogo base/instalador e se o fechamento da `specsfy-07-implement` deve fazer handoff automático para `$specsfy-08-operational-audit`.

## Conteúdo

- `skills/specsfy-08-operational-audit/SKILL.md`
- `skills/specsfy-08-operational-audit/agents/openai.yaml`
- `skills/tests/test_operational_audit.py`
- `docs/user/skills/specsfy-08-operational-audit.md`

## Casos cobertos pelo contrato

- SPEC sem migration → migrations não viram pendência por precaução;
- dívida global de backup/criptografia → fica fora da contagem da feature;
- processo de release desconhecido → só vira `INCERTO` quando existe necessidade causal comprovada;
- assets validados localmente → não são confundidos automaticamente com publicação nem com runtime funcional;
- migration aplicada → ainda exige plano de revalidação quando aplicável;
- interface/rota alterada → pode exigir validação manual em runtime;
- servidor local/dev → não é deploy;
- uma causa raiz de release não documentado → não é inflada em várias pendências independentes.

## Validação

Os testes de contrato cobrem:

- escopo pós-feature e fronteira somente leitura;
- regra de causalidade;
- separação de dívida global;
- revalidação pós-ação;
- distinção entre build, runtime e deploy;
- relatório estendido de validação;
- metadata de descoberta da nova skill.

Esta proposta é separada do PR #27 porque resolve uma responsabilidade diferente do framework.