### PR TITLE
Torna o contrato de runtime Laravel agnóstico de servidor

### DIFF
--- a/skills/Spec.md
+++ b/skills/Spec.md
@@ -150,11 +150,25 @@ input → inbox → backlog → spec → validate → tasks → TDD/BDD → impl
 
 ## Contrato de runtime Laravel
 
-Toda aplicação Laravel usa Laravel Octane como servidor de aplicação. O pacote
-`laravel/octane` é obrigatório com Open Swoole. O Octane usa o identificador
-`swoole` para esse servidor. Código executado por workers persistentes não pode manter
-estado de uma requisição para a seguinte. Build, healthcheck, reload e deploy
-devem exercitar o processo Octane que atende o tráfego real.
+Toda aplicação Laravel declara explicitamente seu servidor de aplicação em
+`.specsfy/STACK.md`, com a evidência que o comprova: o comando que sobe o
+processo, a imagem e as extensões exigidas. Build, healthcheck, reload e deploy
+devem exercitar o mesmo processo que atende o tráfego real; validar um servidor
+diferente do que roda em produção não é evidência.
+
+Qual servidor adotar é decisão do projeto, não do framework. PHP-FPM,
+FrankenPHP em modo clássico, FrankenPHP em worker mode e Laravel Octane com
+Swoole, Open Swoole, RoadRunner ou FrankenPHP são escolhas legítimas, cada uma
+com um custo. O contrato exige que a escolha seja explícita e comprovada, não
+que seja uma em particular.
+
+Modo worker — Octane com qualquer driver, FrankenPHP em worker mode,
+RoadRunner — boota a aplicação uma única vez e a reaproveita entre requisições.
+Sob ele, o código não pode manter estado de uma requisição para a seguinte:
+property estática, singleton que guarda usuário ou `Request`, e cache em
+memória de processo passam a vazar de um usuário para outro. Adotar modo worker
+exige auditar esses pontos antes de ligar, não apenas trocar o comando de
+inicialização; trate essa auditoria como spec própria.
 
 ## Contrato de experiência de interface
 

--- a/skills/specsfy-setup/SKILL.md
+++ b/skills/specsfy-setup/SKILL.md
@@ -307,11 +307,19 @@ Para todo projeto Laravel com React, o setup instala shadcn/ui e ReUI juntos.
 Não trate essa dupla como opcional: shadcn/ui prepara a base e ReUI cria CRUDs
 e interfaces sobre ela.
 
-Para toda aplicação Laravel, Laravel Octane com Open Swoole é obrigatório.
-Confira `laravel/octane` em `composer.json` e `composer.lock`, a extensão
-`openswoole` na imagem e `--server=swoole` no runtime. Registre essa combinação
-em `.specsfy/STACK.md` e encaminhe a instalação ou correção ausente para uma
-spec antes de aprovar o setup.
+Para toda aplicação Laravel, confirme qual servidor de aplicação atende o
+tráfego e registre-o em `.specsfy/STACK.md` com a evidência: o comando de
+inicialização no `Dockerfile`, `Procfile` ou equivalente, a imagem e as
+extensões exigidas e, quando houver, o pacote correspondente em `composer.json`
+e `composer.lock`. Variável de ambiente herdada de template não prova nada:
+`OCTANE_SERVER` definido sem `laravel/octane` instalado é linha morta, e
+registrá-la como runtime cria uma stack falsa.
+
+Quando o servidor rodar em modo worker, registre também o reload dos workers e
+encaminhe para uma spec a auditoria de estado entre requisições. Não exija um
+servidor específico nem bloqueie o setup por causa da escolha do projeto:
+bloqueie apenas quando o servidor não estiver declarado ou quando a evidência
+contradisser o que roda.
 
 Depois de instalar a dupla, o setup registra em `INTERFACE.md` que telas React
 são compostas por componentes. Cada nova tela deve consultar o mapa, reutilizar

--- a/skills/templates/Spec.md
+++ b/skills/templates/Spec.md
@@ -242,9 +242,9 @@ tests/
 
 - [Hierarquia, navegação, `Breadcrumb` no shell, regiões da tela, densidade,
   responsividade e componentes existentes.]
-- [Em aplicação Laravel, Laravel Octane com Open Swoole e `laravel/octane` são
-  obrigatórios. Registre `--server=swoole`, o healthcheck e o reload dos
-  workers persistentes.]
+- [Em aplicação Laravel, registre o servidor de aplicação declarado em
+  `.specsfy/STACK.md`, o comando que o sobe e o healthcheck. Em modo worker,
+  registre também o reload e a auditoria de estado entre requisições.]
 
 #### Blocos React e componentes selecionados
 

--- a/skills/tests/test_interface_contract.py
+++ b/skills/tests/test_interface_contract.py
@@ -404,7 +404,7 @@ class InterfaceContractTests(unittest.TestCase):
         self.assertIn("em toda execução completa do setup", normalized.casefold())
         self.assertIn("$specsfy-documentator", normalized)
 
-    def test_laravel_projects_require_octane_as_the_application_server(self) -> None:
+    def test_laravel_projects_declare_their_application_server(self) -> None:
         sources = (
             ROOT / "Spec.md",
             ROOT / "templates" / "Spec.md",
@@ -414,11 +414,22 @@ class InterfaceContractTests(unittest.TestCase):
 
         for source in sources:
             with self.subTest(source=source):
-                content = source.read_text(encoding="utf-8")
-                self.assertIn("Laravel Octane", content)
-                self.assertIn("obrigatório", content)
-                self.assertIn("laravel/octane", content)
-                self.assertIn("Open Swoole", content)
+                normalized = " ".join(source.read_text(encoding="utf-8").split())
+                self.assertIn("servidor de aplicação", normalized)
+
+        contrato = (ROOT / "Spec.md").read_text(encoding="utf-8")
+        secao = contrato.split("## Contrato de runtime Laravel", 1)[1].split("\n## ", 1)[0]
+        normalizada = " ".join(secao.split())
+
+        self.assertIn("declara explicitamente seu servidor de aplicação", normalizada)
+        self.assertIn("exercitar o mesmo processo que atende o tráfego real", normalizada)
+        # Modo worker é o risco real, e vale para qualquer servidor que
+        # reaproveite a aplicação entre requisições.
+        self.assertIn("não pode manter estado de uma requisição para a seguinte", normalizada)
+        # Qual servidor adotar é decisão do projeto: o contrato não pode
+        # tornar nenhum deles obrigatório.
+        self.assertIn("decisão do projeto, não do framework", normalizada)
+        self.assertNotIn("obrigatório", normalizada)
 
     def test_reui_specialist_documents_free_registry_setup(self) -> None:
         reui = (ROOT.parent / "specialists" / "specsfy-specialist-reui" / "SKILL.md").read_text(encoding="utf-8")

--- a/specialists/specsfy-specialist-deploy/SKILL.md
+++ b/specialists/specsfy-specialist-deploy/SKILL.md
@@ -21,7 +21,7 @@ description: Orquestrar release e deploy em servidor com SEMVER, Docker Swarm e 
    `$specsfy-specialist-versioning` para ler ou preparar `SEMVER`.
 2. Inspecionar `Dockerfile`, Compose, stack e `ansible/` existentes. Comparar
    PHP, extensões, dependências, assets, entrypoint, usuário interno, portas,
-   healthcheck e comando do Octane com a aplicação atual. Preservar trechos
+   healthcheck e comando do servidor de aplicação com a aplicação atual. Preservar trechos
    personalizados e apresentar o diff antes de substituir um arquivo sem
    marcações gerenciadas.
 3. Executar o gerador somente na primeira preparação, quando todos os destinos
@@ -87,8 +87,12 @@ description: Orquestrar release e deploy em servidor com SEMVER, Docker Swarm e 
 - Gerar `compose.yaml` para desenvolvimento e `stack.yaml` para produção.
   Toda produção usa a stack pelo Docker Swarm; não use Compose como runtime de
   produção.
-- Em Laravel, exigir `laravel/octane` e Open Swoole. A imagem instala
-  `openswoole`; Compose e stack executam Octane com `--server=swoole`.
+- Em Laravel, gerar por padrão `laravel/octane` com Open Swoole: a imagem
+  instala `openswoole` e Compose e stack executam Octane com
+  `--server=swoole`. Quando o projeto já declarar outro servidor em
+  `.specsfy/STACK.md`, respeitar a declaração e gerar para ele; migrar de
+  servidor é decisão do projeto e pede spec própria, nunca um efeito colateral
+  da preparação do deploy.
 - Sugerir Cloudflare Tunnel como entrada pública padrão. Executar `cloudflared`
   como serviço da stack, ligado à mesma rede overlay da aplicação e sem porta
   pública no serviço Laravel. O hostname do túnel aponta para `http://app:8000`.

--- a/specialists/specsfy-specialist-deploy/references/standards.md
+++ b/specialists/specsfy-specialist-deploy/references/standards.md
@@ -6,9 +6,11 @@ O playbook separa roles para host Debian, Docker Engine, Docker Swarm e
 aplicação. A automação configura repositório de pacotes, daemon, rotação de
 logs, firewall, diretórios, registry e redes antes de publicar a stack.
 
-Aplicações Laravel usam Laravel Octane com Open Swoole. A imagem instala a
-extensão `openswoole`, enquanto o Compose e a stack executam
-`octane:start --server=swoole`.
+O padrão gerado para Laravel é Laravel Octane com Open Swoole: a imagem
+instala a extensão `openswoole` e o Compose e a stack executam
+`octane:start --server=swoole`. Esse é o ponto de partida, não uma exigência —
+um projeto que declare PHP-FPM ou FrankenPHP em `.specsfy/STACK.md` mantém o
+próprio servidor, e a stack passa a exercitar o processo dele.
 
 O ingresso público padrão usa Cloudflare Tunnel. A stack executa `cloudflared`
 como serviço na mesma rede overlay do Laravel, e o hostname configurado no

--- a/specialists/specsfy-specialist-laravel/SKILL.md
+++ b/specialists/specsfy-specialist-laravel/SKILL.md
@@ -24,10 +24,11 @@ description: Implementar, revisar e operar aplicações Laravel — HTTP, Eloque
 1. Ler `composer.json`/`composer.lock` para confirmar versão do framework,
    PHP e pacotes relevantes (Sanctum, Horizon, Octane, Scout) antes de supor
    comportamento por memória.
-2. Tratar Laravel Octane com Open Swoole e o pacote `laravel/octane` como
-   runtime obrigatório. Quando estiver ausente,
-   incluir instalação e configuração no trabalho antes de considerar a
-   aplicação pronta para execução ou deploy.
+2. Confirmar qual servidor de aplicação atende o tráfego — PHP-FPM,
+   FrankenPHP, Octane com algum driver — pelo comando de inicialização e pelos
+   manifests, não por variável de ambiente herdada de template. Quando o
+   projeto não declarar servidor algum, tratar isso como lacuna a resolver
+   antes de considerar a aplicação pronta para deploy.
 3. Mapear a requisição do ponto de entrada até domínio, persistência,
    efeitos assíncronos e resposta, identificando o boundary onde a regra de
    negócio já vive no projeto (Action, Service, Model rico).
@@ -53,9 +54,11 @@ description: Implementar, revisar e operar aplicações Laravel — HTTP, Eloque
 
 ## Padrões
 
-- Executar HTTP com Laravel Octane, Open Swoole e `--server=swoole`. Instalar a
-  extensão `openswoole` na imagem e limpar estado por requisição; singletons e propriedades estáticas
-  não podem transportar dados entre usuários nos workers persistentes.
+- Executar HTTP pelo servidor que o projeto declarou, e exercitar esse mesmo
+  processo em build, healthcheck e deploy. Sob modo worker — Octane com
+  qualquer driver, FrankenPHP em worker mode, RoadRunner — limpar estado por
+  requisição: singleton, propriedade estática e cache em memória de processo
+  não podem transportar dados de um usuário para o próximo.
 - Manter controllers finos: validação em Form Requests, autorização em
   Policies/Gates, regra de negócio no boundary já adotado pelo projeto.
 - Tratar Eloquent como acesso a dados: eager load explícito (`with`,

--- a/specialists/specsfy-specialist-laravel/references/standards.md
+++ b/specialists/specsfy-specialist-laravel/references/standards.md
@@ -66,13 +66,16 @@
 
 ## Operação
 
-- Laravel Octane com Open Swoole e `laravel/octane` é o runtime HTTP
-  obrigatório. Instale `openswoole` por PECL na imagem, execute
-  `octane:start --server=swoole`, configure o healthcheck no processo Octane e
-  recarregue os workers durante o deploy.
-- Revise singletons, estado estático e callbacks capturados: workers Octane
-  persistem entre requisições e não podem carregar dados de um usuário para o
-  próximo.
+- O runtime HTTP é declarado pelo projeto em `.specsfy/STACK.md`. Configure o
+  healthcheck no processo que de fato atende o tráfego e, em modo worker,
+  recarregue os workers durante o deploy. Uma composição comum é Octane com
+  `octane:start --server=swoole` e a extensão instalada por PECL na imagem, mas
+  FrankenPHP e PHP-FPM são alternativas legítimas.
+- Revise singletons, estado estático e callbacks capturados sempre que o
+  servidor for de modo worker: o processo persiste entre requisições e não pode
+  carregar dados de um usuário para o próximo. Em modo clássico, uma bootagem
+  por requisição, esse risco não existe — o que se abre mão é de performance,
+  não de correção.
 - `config:cache`, `route:cache`, `event:cache` reduzem I/O de boot; qualquer
   um deles fica obsoleto silenciosamente se o deploy não os regenerar após
   mudar config/rotas/listeners — automatizar no pipeline, não como passo
@@ -126,7 +129,7 @@
 ## Fontes oficiais
 
 - [Documentação Laravel](https://laravel.com/docs)
-- [Laravel Octane e Open Swoole](https://laravel.com/docs/octane#swoole)
+- [Laravel Octane e seus servidores](https://laravel.com/docs/octane)
 - [Ciclo de vida da requisição](https://laravel.com/docs/lifecycle)
 - [Relacionamentos Eloquent e eager loading](https://laravel.com/docs/eloquent-relationships)
 - [Autorização com Policies e Gates](https://laravel.com/docs/authorization)


### PR DESCRIPTION
## O problema

O `Contrato de runtime Laravel` exige hoje que **toda** aplicação Laravel use Octane com Open Swoole, e a `specsfy-setup` manda bloquear a aprovação e encaminhar uma spec de instalação quando `laravel/octane` estiver ausente.

Isso transforma uma decisão do projeto em regra do framework. Um projeto que sirva por PHP-FPM ou por FrankenPHP em modo clássico — com o runtime declarado, comprovado e funcionando — é reprovado no setup por causa da escolha, não por falta de evidência.

Foi o que aconteceu num projeto consumidor nosso: ele roda `frankenphp php-server` em modo clássico por decisão registrada, e a cada `specsfy update` o contrato volta a exigir um pacote que ele deliberadamente não tem.

## O que muda

**O núcleo verificável do contrato é preservado**, porque ele nunca foi o Octane: declarar explicitamente qual processo atende o tráfego, e exercitar esse mesmo processo em build, healthcheck, reload e deploy. Validar um servidor diferente do que roda em produção não é evidência — e isso vale para qualquer servidor.

**O risco real ganha o nome certo.** Quem faz estado vazar entre usuários não é o Octane, é o **modo worker**: property estática, singleton que guarda usuário ou `Request`, cache em memória de processo. Vale para Octane com qualquer driver, FrankenPHP em worker mode e RoadRunner; não vale para modo clássico, onde cada requisição boota do zero. O contrato passa a nomear o modo, não o pacote, e pede a auditoria como spec própria antes de ligar — porque adotar worker não é trocar o comando de inicialização.

**A `specsfy-setup` deixa de bloquear pela escolha** e passa a bloquear pelo que de fato é defeito: servidor não declarado, ou evidência que contradiz o que roda. Ela ganha um caso concreto que já nos mordeu: `OCTANE_SERVER` definido sem `laravel/octane` instalado é linha morta herdada de template, e registrá-la como runtime cria uma stack falsa.

**O `specsfy-specialist-deploy` mantém o padrão que já gerava.** O scaffold continua produzindo Octane com Open Swoole, e `specialists/tests/test_deploy_specialist.py` segue intacto. O que muda é que "exigir" virou "gerar por padrão": um projeto que já declarou outro servidor mantém o dele, e migrar de servidor passa a pedir spec própria em vez de acontecer como efeito colateral da preparação do deploy.

## Sobre o driver único

Laravel Octane suporta FrankenPHP, Open Swoole, Swoole e RoadRunner — está no README dele. Então a exigência de Open Swoole estreitava sem motivo mesmo dentro do próprio Octane.

## Testes

`skills/tests/test_interface_contract.py::test_laravel_projects_require_octane_as_the_application_server` codificava a regra antiga. Reescrevi para a nova, com o mesmo alcance de quatro fontes: cada uma precisa falar de servidor de aplicação, e a seção do contrato precisa exigir declaração, evidência e cuidado com estado em modo worker — com um `assertNotIn("obrigatório")` na seção, para que a regra não volte por descuido.

```
skills/       → python3 -B -m unittest discover -s tests -p 'test_*.py'   →  125 testes, OK
specialists/  → 25 testes, 1 falha: shellcheck ausente nesta máquina
raiz/         → 111 testes, 3 falhas + 3 erros
```

As falhas de `specialists/` e da raiz são do ambiente, não da mudança: `shellcheck` não instalado, artefatos do ebook não construídos, e `test_public_origin_is_the_promovaweb_monorepo` reclamando do remote porque estou num fork. Confirmei rodando a suíte da raiz com as mudanças em `git stash`: exatamente as mesmas seis.

## Fora do escopo

Não toquei em `example/`, que é o snapshot instalado da aplicação de validação e se regenera pelo CLI. `specsfy-specialist-docker` cita Octane só como exemplo de filesystem compartilhado, sem exigência, e ficou como está.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157TAF51Hp5uFdAsHM3Nniy
