### PR TITLE
fix(lifecycle): permite reabrir specs concluídas

### DIFF
--- a/cli/src/lifecycle.ts
+++ b/cli/src/lifecycle.ts
@@ -42,7 +42,7 @@ const NEXT_FOLDERS: Record<SpecFolder, readonly SpecFolder[]> = {
   planned: ["defined", "planned", "in-progress"],
   "in-progress": ["planned", "in-progress", "review"],
   review: ["in-progress", "review", "completed"],
-  completed: ["completed"],
+  completed: ["draft", "defined", "completed"],
 };
 
 const TABLE_STATUS = /^(\|\s*Status\s*\|\s*)([^|]*)(\|\s*)$/imu;

--- a/cli/tests/lifecycle.test.ts
+++ b/cli/tests/lifecycle.test.ts
@@ -43,6 +43,45 @@ describe("ciclo de vida das specs", () => {
     });
   });
 
+  test("reabre spec concluída desde o Ato I", async () => {
+    const project = await temporaryDirectory();
+    await createSpec(project, "specs/completed/0042-login-social", "Complete");
+
+    const result = await transitionSpec(project, "0042-login-social", "draft");
+
+    expect(result).toMatchObject({
+      from: "completed",
+      to: "draft",
+      status: "Draft",
+    });
+    const target = join(project, "specs/draft/0042-login-social/spec.md");
+    expect(await readFile(target, "utf8")).toContain("| Status | Draft |");
+  });
+
+  test("reabre spec concluída somente desde o Ato II", async () => {
+    const project = await temporaryDirectory();
+    await createSpec(project, "specs/completed/0042-login-social", "Complete");
+
+    const result = await transitionSpec(project, "0042-login-social", "defined");
+
+    expect(result).toMatchObject({
+      from: "completed",
+      to: "defined",
+      status: "Defined",
+    });
+    const target = join(project, "specs/defined/0042-login-social/spec.md");
+    expect(await readFile(target, "utf8")).toContain("| Status | Defined |");
+  });
+
+  test("spec concluída não pula diretamente para planned", async () => {
+    const project = await temporaryDirectory();
+    await createSpec(project, "specs/completed/0042-login-social", "Complete");
+
+    await expect(
+      transitionSpec(project, "0042-login-social", "planned"),
+    ).rejects.toThrow("completed para planned");
+  });
+
   test("recusa transições que pulam estados", async () => {
     const project = await temporaryDirectory();
     await createSpec(project, "specs/draft/0042-login-social", "Draft");


### PR DESCRIPTION
## Contexto

A skill `specsfy-update-spec` suporta mudanças tardias em specs já concluídas e determina reabrir os atos invalidados antes de restaurar `Complete`.

Hoje o CLI bloqueia qualquer saída de `completed`, porque o lifecycle define `completed: ["completed"]`. Isso impede o fluxo documentado pela própria skill para:

- mudança de Ato I: `Complete -> Draft`;
- mudança somente de Ato II: `Complete -> Defined`.

## Alteração

Este PR ajusta o lifecycle para permitir:

- `completed -> draft`;
- `completed -> defined`;
- manter `completed -> completed`;
- continuar rejeitando salto direto `completed -> planned`.

Também adiciona testes cobrindo os três casos.

## Validação

A correção foi validada em dois níveis:

1. CLI/framework
   - 19 arquivos de teste;
   - 109 testes aprovados;
   - `typecheck` aprovado;
   - `build` aprovado.

2. Projeto consumidor real
   - uma spec em `Complete` foi reaberta oficialmente para `Draft`;
   - o fluxo seguiu `Draft -> Defined -> Planned -> In Progress -> Review -> Complete`;
   - os gates foram revalidados;
   - a entrega voltou a `Complete` com evidências e testes aprovados.

O PR é intencionalmente pequeno e não altera nenhuma outra transição do ciclo de vida.